### PR TITLE
chore(ci): Add OK to bump workflow

### DIFF
--- a/.github/workflows/bump_versions.yml
+++ b/.github/workflows/bump_versions.yml
@@ -1,0 +1,42 @@
+name: Bump Versions
+
+on:
+  repository_dispatch:
+    types: [bump-command]
+
+jobs:
+  ok_to_bump:
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.manually_approved.outputs.result }}
+    steps:
+      - name: Check if was manually approved
+        id: manually_approved
+        run: |
+          manually_approved=${{ github.event_name == 'repository_dispatch' && github.event.client_payload.slash_command.args.named.sha != '' && contains(github.event.client_payload.pull_request.head.sha, github.event.client_payload.slash_command.args.named.sha) }}
+          echo ::set-output name=result::"$manually_approved"
+  bump:
+    permissions:
+      id-token: write
+      contents: read
+    needs: [ok_to_test]
+    if: github.event_name == 'repository_dispatch' && needs.ok_to_bump.outputs.status == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.client_payload.slash_command.args.named.sha }}
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          token: ${{ secrets.GH_CQ_BOT }}
+
+      - name: Update chart version
+        run: 'sed -i "s/^version.*/version: $(grep ''^version'' charts/cloudquery/Chart.yaml | cut -d" " -f2 | awk -F. ''{$NF = $NF + 1;} 1'' | sed ''s/ /./g'')/g" charts/cloudquery/Chart.yaml'
+
+      - name: Update Docs
+        run: |
+          docker run --rm --volume "$(pwd):/helm-docs" -u "$(id -u)" jnorwood/helm-docs:v1.11.0
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "chore: Update version and docs"

--- a/.github/workflows/ok_to_bump_version.yml
+++ b/.github/workflows/ok_to_bump_version.yml
@@ -1,0 +1,18 @@
+name: Dispatch Bump Version Command
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  manual-approve:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Bump Version Command
+        uses: peter-evans/slash-command-dispatch@v3
+        with:
+          token: ${{ secrets.GH_CQ_BOT }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-type: pull-request
+          commands: bump
+          permission: write


### PR DESCRIPTION
This should allow us to comment on PRs such https://github.com/cloudquery/helm-charts/pull/92 with `/bump sha=<sha>` to add another commit that updates the version and docs