### PR TITLE
chore: Update chart version on dep updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,6 +12,7 @@
   ],
   packageRules: [
     {
+      matchManagers: ["helm-values", "helmv3"],
       matchPackageNames: ["cloudquery/cloudquery"],
       extractVersion: "^cli/v(?<version>.+)\\.\\d$",
       postUpgradeTasks: {


### PR DESCRIPTION
This ensures we update chart version and docs after dep updates such as https://github.com/cloudquery/helm-charts/pull/90