### PR TITLE
chore: Fix renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,6 @@
     {
       matchManagers: ["helm-values", "helmv3"],
       matchPackageNames: ["cloudquery/cloudquery"],
-      extractVersion: "^cli/v(?<version>.+)\\.\\d$",
       postUpgradeTasks: {
         commands: [
           // Bump patch version of chart when updating the CloudQuery CLI version
@@ -29,6 +28,10 @@
         executionMode: "update",
       },
       automerge: true,
+    },
+    {
+      matchPackageNames: ["cloudquery/cloudquery"],
+      extractVersion: "^cli/v(?<version>.+)\\.\\d$",
     },
   ],
 }


### PR DESCRIPTION
Follow up to https://github.com/cloudquery/helm-charts/pull/95.

`postUpgradeTasks` should be the same, but `extractVersion` is only for the CLI (CloudQuery)