### PR TITLE
chore: Use `fix` commit type when updating CloudQuery

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,6 +38,7 @@
       schedule: ["at any time"],
       matchPackageNames: ["cloudquery/cloudquery"],
       extractVersion: "^cli/v(?<version>.+)\\.\\d$",
+      commitMessagePrefix: "fix(deps): ",
     },
   ],
 }


### PR DESCRIPTION
Our default for regex managers is `chore` but in case of the CLI it should be `fix`