### PR TITLE
chore: Use action instead of event_type

### DIFF
--- a/.github/workflows/manual_triggers.yml
+++ b/.github/workflows/manual_triggers.yml
@@ -15,17 +15,12 @@ jobs:
         run: |
           manually_approved=${{ github.event_name == 'repository_dispatch' && github.event.client_payload.slash_command.args.named.sha != '' && contains(github.event.client_payload.pull_request.head.sha, github.event.client_payload.slash_command.args.named.sha) }}
           echo ::set-output name=result::"$manually_approved"
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: |
-          echo "$GITHUB_CONTEXT"
   bump:
     permissions:
       id-token: write
       contents: read
     needs: [ok-to-run]
-    if: github.event_name == 'repository_dispatch' && github.event.event_type == 'bump-command' && needs.ok-to-run.outputs.status == 'true'
+    if: github.event_name == 'repository_dispatch' && github.event.action == 'bump-command' && needs.ok-to-run.outputs.status == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -51,7 +46,7 @@ jobs:
       id-token: write
       contents: read
     needs: [ok-to-run]
-    if: github.event_name == 'repository_dispatch' && github.event.event_type == 'docs-command' && needs.ok-to-run.outputs.status == 'true'
+    if: github.event_name == 'repository_dispatch' && github.event.action == 'docs-command' && needs.ok-to-run.outputs.status == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Docs say one thing, but logs show another thing:
https://github.com/cloudquery/helm-charts/actions/runs/3088658202/jobs/4995394315#step:3:29
![image](https://user-images.githubusercontent.com/26760571/191212135-451093f6-ca0c-4e57-924f-297bf4523295.png)

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch:
![image](https://user-images.githubusercontent.com/26760571/191212335-5e2d38d6-59ec-44de-b646-c4bbc80356ee.png)
