### PR TITLE
feat: Allow to choose whether to create the secret

### DIFF
--- a/charts/cloudquery/Chart.yaml
+++ b/charts/cloudquery/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 
 # -- This is the version number of the application being deployed.This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudquery/README.md
+++ b/charts/cloudquery/README.md
@@ -1,6 +1,6 @@
 # cloudquery
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.32](https://img.shields.io/badge/AppVersion-0.32-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.32](https://img.shields.io/badge/AppVersion-0.32-informational?style=flat-square)
 
 The open-source cloud asset inventory powered by SQL.
 

--- a/charts/cloudquery/templates/admin-deployment.yaml
+++ b/charts/cloudquery/templates/admin-deployment.yaml
@@ -24,9 +24,13 @@ spec:
           env:
           - name: CQ_INSTALL_SRC
             value: "{{ .Values.cqInstallSrc | default "HELM" }}"
-          envFrom:
+          envFrom:          
           - secretRef:
+              {{- if .Values.secretRef}}
+              name: {{ .Values.secretRef }}              
+              {{- else}}              
               name: {{ include "cloudquery.fullname" . }}-secret
+              {{- end}}
           image: "{{ include "cloudquery.image" . }}"
           imagePullPolicy: Always
           command: ["/bin/sh"]

--- a/charts/cloudquery/templates/cronjob.yaml
+++ b/charts/cloudquery/templates/cronjob.yaml
@@ -25,7 +25,11 @@ spec:
                 value: "{{ .Values.cqInstallSrc | default "HELM" }}"
               envFrom:
               - secretRef:
-                  name: {{ include "cloudquery.fullname" . }}-secret
+                  {{- if .Values.secretRef}}
+                  name: {{ .Values.secretRef }}
+                  {{- else}}
+                  name: {{ include "cloudquery.fullname" . }}-secret                
+                  {{- end}}
               image: "{{ include "cloudquery.image" . }}"
               imagePullPolicy: Always
               args: ["fetch", "--config", "/app/config/cloudquery.yml", "--enable-console-log", "--encode-json"]

--- a/charts/cloudquery/templates/secret.yaml
+++ b/charts/cloudquery/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.envRenderSecret}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,4 +9,5 @@ type: Opaque
 data:
 {{- range $k, $v := .Values.envRenderSecret }}
   {{ $k }}: {{ $v | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/charts/cloudquery/templates/secret.yaml
+++ b/charts/cloudquery/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.envRenderSecret}}
+{{- if not .Values.secretRef}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/cloudquery/values.yaml
+++ b/charts/cloudquery/values.yaml
@@ -52,6 +52,11 @@ envRenderSecret: {}
 
   # For any other provider checkout https://hub.cloudquery.io/providers
 
+# -- Reference to an external secret that contains sensible environment variables
+# This option is useful to avoid store sensitive values in Git. You need to create the secret manually and reference it.
+# If secretRef is used, the envRenderSecret parameter will be omitted (in case that it has content). 
+secretRef: 
+
 # -- Schedule fetch time Every 6 hours.
 # More information at: https://crontab.guru/#0_0_*_*_*
 schedule: "0 */6 * * *"


### PR DESCRIPTION
Currently the helm chart always creates the secret with the sensible environment variables, even if the `envRenderSecret` is empty. It will create a secret without any value. If after the creation of the secret someone wants to add an environment variable to the secret manually, to avoid commit sensitive values to git, it will create a drift with the original manifest of the secret. 

This PR is just to avoid those cases when you add the secret manually.