### PR TITLE
chore: Fix renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -36,7 +36,7 @@
     {
       schedule: ["at any time"],
       matchPackageNames: ["cloudquery/cloudquery"],
-      extractVersion: "^cli/v(?<version>.+)\\.\\d$",
+      extractVersion: "^cli-v(?<version>.+)\\.\\d$",
       commitMessagePrefix: "fix(deps): ",
     },
   ],


### PR DESCRIPTION
This is required since we use a tag structure of `cli-v` instead of `cli/v` now