### PR TITLE
chore(deps): Configure renovate to update plugin versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,12 +7,31 @@
       depNameTemplate: "cloudquery/cloudquery",
       datasourceTemplate: "github-releases",
       versioningTemplate: "loose",
+      extractVersionTemplate: "^cli-v(?<version>.+)\\.\\d$",
     },
     {
       fileMatch: ["^.github/workflows/.+.ya?ml$", "^.github/renovate.json5$"],
       matchStrings: ["jnorwood\\/helm-docs\\:(?<currentValue>.*\\d)"],
       depNameTemplate: "jnorwood/helm-docs",
       datasourceTemplate: "docker",
+    },
+    {
+      fileMatch: ["^charts/cloudquery/values.yaml$"],
+      matchStrings: [
+        'version: "(?<currentValue>.*)" # latest version of aws plugin',
+      ],
+      depNameTemplate: "cloudquery/cloudquery",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^plugins-source-aws-v(?<version>.+)\\.\\d$",
+    },
+    {
+      fileMatch: ["^charts/cloudquery/values.yaml$"],
+      matchStrings: [
+        'version: "(?<currentValue>.*)" # latest version of postgresql plugin',
+      ],
+      depNameTemplate: "cloudquery/cloudquery",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^plugins-destination-postgresql-v(?<version>.+)\\.\\d$",
     },
   ],
   packageRules: [
@@ -36,7 +55,6 @@
     {
       schedule: ["at any time"],
       matchPackageNames: ["cloudquery/cloudquery"],
-      extractVersion: "^cli-v(?<version>.+)\\.\\d$",
       commitMessagePrefix: "fix(deps): ",
     },
   ],


### PR DESCRIPTION
To be merged after https://github.com/cloudquery/helm-charts/pull/117, so renovate updates CLI, AWS plugin and PostgresSQL plugin in the chart