### PR TITLE
chore(deps): Fix renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,7 +22,7 @@
       ],
       depNameTemplate: "cloudquery/cloudquery",
       datasourceTemplate: "github-releases",
-      extractVersionTemplate: "^plugins-source-aws-v(?<version>.+)\\.\\d$",
+      extractVersionTemplate: "^plugins-source-aws-v(?<version>.+)$",
     },
     {
       fileMatch: ["^charts/cloudquery/values.yaml$"],
@@ -31,7 +31,7 @@
       ],
       depNameTemplate: "cloudquery/cloudquery",
       datasourceTemplate: "github-releases",
-      extractVersionTemplate: "^plugins-destination-postgresql-v(?<version>.+)\\.\\d$",
+      extractVersionTemplate: "^plugins-destination-postgresql-v(?<version>.+)$",
     },
   ],
   packageRules: [


### PR DESCRIPTION
For the plugins we need the full version (for the CLI we use "loose" version matching https://github.com/cloudquery/helm-charts/blob/b085177a6f969ecd14b6091ac004a0e15d2fd603/.github/renovate.json5#L9, https://github.com/cloudquery/helm-charts/blob/b085177a6f969ecd14b6091ac004a0e15d2fd603/charts/cloudquery/Chart.yaml#L26)