### PR TITLE
chore(deps): Fix renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,7 +22,7 @@
       ],
       depNameTemplate: "cloudquery/cloudquery",
       datasourceTemplate: "github-releases",
-      extractVersionTemplate: "^plugins-source-aws-v(?<version>.+)$",
+      extractVersionTemplate: "^plugins-source-aws-(?<version>.+)$",
     },
     {
       fileMatch: ["^charts/cloudquery/values.yaml$"],
@@ -31,7 +31,7 @@
       ],
       depNameTemplate: "cloudquery/cloudquery",
       datasourceTemplate: "github-releases",
-      extractVersionTemplate: "^plugins-destination-postgresql-v(?<version>.+)$",
+      extractVersionTemplate: "^plugins-destination-postgresql-(?<version>.+)$",
     },
   ],
   packageRules: [


### PR DESCRIPTION
Almost there, we need the `v` too in the version https://github.com/cloudquery/helm-charts/pull/125/files