### PR TITLE
feat: Add more options for helm chart - labels, annotations. securityContexts & cronjob arguments

### DIFF
--- a/charts/cloudquery/Chart.yaml
+++ b/charts/cloudquery/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.35
+version: 1.0.36
 
 # -- This is the version number of the application being deployed.This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudquery/README.md
+++ b/charts/cloudquery/README.md
@@ -1,6 +1,6 @@
 # cloudquery
 
-![Version: 1.0.38](https://img.shields.io/badge/Version-1.0.37-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5](https://img.shields.io/badge/AppVersion-1.5-informational?style=flat-square)
+![Version: 1.0.38](https://img.shields.io/badge/Version-1.0.38-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5](https://img.shields.io/badge/AppVersion-1.5-informational?style=flat-square)
 
 Open source high performance data integration platform designed for security and infrastructure teams.
 

--- a/charts/cloudquery/README.md
+++ b/charts/cloudquery/README.md
@@ -29,8 +29,7 @@ Kubernetes: `^1.8.0-0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | config | string | The chart will use a default CloudQuery aws config | CloudQuery cloudquery.yml content |
-| containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
-| containerSecurityContext.capabilities.drop[0] | string | `"all"` |  |
+| containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]}}` | Container security context |
 | cronJobAdditionalArgs | list | `[]` |  |
 | cronJobPodAnnotations | object | `{}` |  |
 | deploymentAnnotations | object | `{}` |  |
@@ -46,7 +45,7 @@ Kubernetes: `^1.8.0-0`
 | promtail.enabled | bool | `false` |  |
 | schedule | string | `"0 */6 * * *"` | Schedule fetch time Every 6 hours. More information at: https://crontab.guru/#0_0_*_*_* |
 | secretRef | string | `nil` | Reference to an external secret that contains sensible environment variables This option is useful to avoid store sensitive values in Git. You need to create the secret manually and reference it. If secretRef is used, the envRenderSecret parameter will be omitted (in case that it has content). |
-| securityContext.fsGroup | int | `1001` |  |
+| securityContext | object | `{"fsGroup":1001}` | Pod security context |
 | serviceAccount | object | `{"annotations":{},"autoMount":false,"enabled":false,"name":""}` | Pod Service Account ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ |
 | serviceAccount.annotations | object | `{}` | Additional custom annotations for the ServiceAccount to associate an AWS IAM role with service-account you need to add the following annotations. For more info checkout: https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/ROLE |
 | serviceAccount.autoMount | bool | `false` | Auto-mount the service account token in the pod |

--- a/charts/cloudquery/README.md
+++ b/charts/cloudquery/README.md
@@ -1,6 +1,6 @@
 # cloudquery
 
-![Version: 1.0.35](https://img.shields.io/badge/Version-1.0.35-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5](https://img.shields.io/badge/AppVersion-1.5-informational?style=flat-square)
+![Version: 1.0.36](https://img.shields.io/badge/Version-1.0.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5](https://img.shields.io/badge/AppVersion-1.5-informational?style=flat-square)
 
 Open source high performance data integration platform designed for security and infrastructure teams.
 
@@ -29,8 +29,10 @@ Kubernetes: `^1.8.0-0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | config | string | The chart will use a default CloudQuery aws config | CloudQuery cloudquery.yml content |
-| containerSecurityContext.enabled | bool | `true` |  |
-| containerSecurityContext.runAsUser | int | `1001` |  |
+| containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
+| containerSecurityContext.capabilities.drop[0] | string | `"all"` |  |
+| cronJobAdditionalArgs | list | `[]` |  |
+| cronJobPodAnnotations | object | `{}` |  |
 | deploymentAnnotations | object | `{}` |  |
 | envRenderSecret | object | `{}` | Sensible environment variables that will be rendered as new secret object This can be useful for auth tokens, etc Make sure not to commit sensitive values to git!! Better use AWS Secret manager (or any other) |
 | fullnameOverride | string | `""` |  |
@@ -38,12 +40,12 @@ Kubernetes: `^1.8.0-0`
 | image.registry | string | `"ghcr.io"` |  |
 | image.repository | string | `"cloudquery/cloudquery"` |  |
 | image.tag | string | `nil` | Overrides the image tag whose default is the chart appVersion |
+| labels | object | `{}` |  |
 | nameOverride | string | `""` | Partially override common.names.fullname template (will maintain the release name) |
 | promtail.config.clients[0].url | string | `"http://loki-gateway/loki/api/v1/push"` |  |
 | promtail.enabled | bool | `false` |  |
 | schedule | string | `"0 */6 * * *"` | Schedule fetch time Every 6 hours. More information at: https://crontab.guru/#0_0_*_*_* |
 | secretRef | string | `nil` | Reference to an external secret that contains sensible environment variables This option is useful to avoid store sensitive values in Git. You need to create the secret manually and reference it. If secretRef is used, the envRenderSecret parameter will be omitted (in case that it has content). |
-| securityContext.enabled | bool | `true` |  |
 | securityContext.fsGroup | int | `1001` |  |
 | serviceAccount | object | `{"annotations":{},"autoMount":false,"enabled":false,"name":""}` | Pod Service Account ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ |
 | serviceAccount.annotations | object | `{}` | Additional custom annotations for the ServiceAccount to associate an AWS IAM role with service-account you need to add the following annotations. For more info checkout: https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/ROLE |

--- a/charts/cloudquery/templates/_helpers.tpl
+++ b/charts/cloudquery/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "cloudquery.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.labels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/cloudquery/templates/admin-deployment.yaml
+++ b/charts/cloudquery/templates/admin-deployment.yaml
@@ -12,12 +12,18 @@ spec:
   template:
     metadata:
       labels:
-      {{- include "cloudquery.selectorLabels" . | nindent 8 }}
+      {{- include "cloudquery.labels" . | nindent 8 }}
+      {{- if .Values.deploymentAnnotations }}
       annotations:
       {{- toYaml .Values.deploymentAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ include "cloudquery.serviceAccountName" . }}
+      {{- end }}
+      {{- if .Values.securityContext }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       {{- end }}
       containers:
         - name: cloudquery
@@ -44,6 +50,10 @@ spec:
           {{- end }}
           - name: config
             mountPath: /app/config
+          {{- if .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- end }}
       volumes:
       {{- if .Values.volumes }}
       {{- toYaml .Values.volumes | nindent 6 }}

--- a/charts/cloudquery/templates/cronjob.yaml
+++ b/charts/cloudquery/templates/cronjob.yaml
@@ -8,15 +8,26 @@ spec:
   schedule: "{{ .Values.schedule }}"
   concurrencyPolicy: Forbid
   jobTemplate:
+    metadata:
+      labels:
+        {{- include "cloudquery.labels" . | nindent 8 }}
     spec:
       backoffLimit: 0
       template:
         metadata:
           labels:
-          {{- include "cloudquery.selectorLabels" . | nindent 12 }}
+          {{- include "cloudquery.labels" . | nindent 12 }}
+          {{- if .Values.cronJobPodAnnotations }}
+          annotations:
+          {{- toYaml .Values.cronJobPodAnnotations | nindent 12 }}
+          {{- end}}
         spec:
           {{- if .Values.serviceAccount.enabled }}
           serviceAccountName: {{ include "cloudquery.serviceAccountName" . }}
+          {{- end }}
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           {{- end }}
           containers:
             - name: cloudquery
@@ -32,7 +43,13 @@ spec:
                   {{- end}}
               image: "{{ include "cloudquery.image" . }}"
               imagePullPolicy: Always
-              args: ["sync", "/app/config/cloudquery.yml", "--log-console"]
+              args:
+              - "sync"
+              - "/app/config/cloudquery.yml"
+              - "--log-console"
+              {{- range .Values.cronJobAdditionalArgs }}
+              - {{ . | quote }}
+              {{- end }}
               resources:
               {{- toYaml .Values.resources | nindent 16 }}
               volumeMounts:
@@ -41,6 +58,11 @@ spec:
               {{- end }}
               - name: config
                 mountPath: /app/config
+                readOnly: true
+              {{- if .Values.securityContext }}
+              securityContext:
+                {{- toYaml .Values.containerSecurityContext | nindent 16 }}
+              {{- end }}
           volumes:
           {{- if .Values.volumes }}
           {{- toYaml .Values.volumes | nindent 10 }}

--- a/charts/cloudquery/values.yaml
+++ b/charts/cloudquery/values.yaml
@@ -10,12 +10,13 @@ image:
   pullPolicy: IfNotPresent
 
 securityContext:
-  enabled: true
   fsGroup: 1001
 
 containerSecurityContext:
-  enabled: true
-  runAsUser: 1001
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - all
 
 # -- Pod Service Account
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
@@ -97,5 +98,15 @@ promtail:
     clients:
       - url: http://loki-gateway/loki/api/v1/push
 
+# Optional. Additional labels to be applied to all resources.
+labels: {}
+
 # Optional. Admin Deployment annotations.
 deploymentAnnotations: {}
+
+# Optional. CronJob Pod annotations.
+cronJobPodAnnotations: {}
+
+# Optional. Additional CLI arguments to pass to the scheduled sync job (e.g. setting log format)
+# More information at: https://www.cloudquery.io/docs/reference/cli/cloudquery
+cronJobAdditionalArgs: []

--- a/charts/cloudquery/values.yaml
+++ b/charts/cloudquery/values.yaml
@@ -9,9 +9,11 @@ image:
   tag:
   pullPolicy: IfNotPresent
 
+# -- Pod security context
 securityContext:
   fsGroup: 1001
 
+# -- Container security context
 containerSecurityContext:
   allowPrivilegeEscalation: false
   capabilities:


### PR DESCRIPTION
Adding a few more options for the helm chart

- additional labels & annotations (includes making the use of labels more consistent)
- use the specified security context (includes some changes to the security contexts so they work)
- ability to pass extra args to the cron job

It should be possible to go a bit further with locking down the securityContexts in a later PR.  Specifically it should be possible to enable `runAsNonRoot`.  Right now that doesn't work because the `/app` directory permissions in the docker image mean you have to run as root.