### PR TITLE
fix: Bump chart to v5

### DIFF
--- a/charts/cloudquery/Chart.yaml
+++ b/charts/cloudquery/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.5
+version: 5.0.0
 
 # -- This is the version number of the application being deployed.This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudquery/README.md
+++ b/charts/cloudquery/README.md
@@ -1,6 +1,6 @@
 # cloudquery
 
-![Version: 4.0.5](https://img.shields.io/badge/Version-4.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0](https://img.shields.io/badge/AppVersion-2.0-informational?style=flat-square)
+![Version: 5.0.0](https://img.shields.io/badge/Version-5.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0](https://img.shields.io/badge/AppVersion-2.0-informational?style=flat-square)
 
 Open source high performance data integration platform designed for security and infrastructure teams.
 


### PR DESCRIPTION
https://github.com/cloudquery/helm-charts/releases/tag/cloudquery-4.0.5 should have been v5 due to the major bump in AWS plugin https://github.com/cloudquery/helm-charts/pull/199