### PR TITLE
feat: Add CronJob History Limits

### DIFF
--- a/charts/cloudquery/Chart.yaml
+++ b/charts/cloudquery/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.0.0
+version: 5.1.0
 
 # -- This is the version number of the application being deployed.This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudquery/README.md
+++ b/charts/cloudquery/README.md
@@ -31,8 +31,8 @@ Kubernetes: `^1.8.0-0`
 | config | string | The chart will use a default CloudQuery aws config | CloudQuery cloudquery.yml content |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]}}` | Container security context |
 | cronJobAdditionalArgs | list | `[]` |  |
-| cronJobFailedJobsLimit | int | `1` | int Number of failed cronjobs to retain. |
-| cronJobLimit | int | `3` | int Number of successful cronjobs to retain. |
+| cronJobFailedJobsLimit | int | `1` | Number of failed cronjobs to retain. |
+| cronJobLimit | int | `3` | Number of successful cronjobs to retain. |
 | cronJobPodAnnotations | object | `{}` |  |
 | deploymentAnnotations | object | `{}` |  |
 | envRenderSecret | object | `{}` | Sensible environment variables that will be rendered as new secret object This can be useful for auth tokens, etc Make sure not to commit sensitive values to git!! Better use AWS Secret manager (or any other) |

--- a/charts/cloudquery/README.md
+++ b/charts/cloudquery/README.md
@@ -1,6 +1,6 @@
 # cloudquery
 
-![Version: 5.0.0](https://img.shields.io/badge/Version-5.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0](https://img.shields.io/badge/AppVersion-2.0-informational?style=flat-square)
+![Version: 5.1.0](https://img.shields.io/badge/Version-5.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0](https://img.shields.io/badge/AppVersion-2.0-informational?style=flat-square)
 
 Open source high performance data integration platform designed for security and infrastructure teams.
 
@@ -31,6 +31,8 @@ Kubernetes: `^1.8.0-0`
 | config | string | The chart will use a default CloudQuery aws config | CloudQuery cloudquery.yml content |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]}}` | Container security context |
 | cronJobAdditionalArgs | list | `[]` |  |
+| cronJobFailedJobsLimit | int | `1` | Number of failed cronjobs to retain. |
+| cronJobLimit | int | `3` | Number of successful cronjobs to retain. |
 | cronJobPodAnnotations | object | `{}` |  |
 | deploymentAnnotations | object | `{}` |  |
 | envRenderSecret | object | `{}` | Sensible environment variables that will be rendered as new secret object This can be useful for auth tokens, etc Make sure not to commit sensitive values to git!! Better use AWS Secret manager (or any other) |

--- a/charts/cloudquery/README.md
+++ b/charts/cloudquery/README.md
@@ -31,8 +31,8 @@ Kubernetes: `^1.8.0-0`
 | config | string | The chart will use a default CloudQuery aws config | CloudQuery cloudquery.yml content |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]}}` | Container security context |
 | cronJobAdditionalArgs | list | `[]` |  |
-| cronJobFailedJobsLimit | int | `1` | Number of failed cronjobs to retain. |
-| cronJobLimit | int | `3` | Number of successful cronjobs to retain. |
+| cronJobFailedJobsLimit | int | `1` | int Number of failed cronjobs to retain. |
+| cronJobLimit | int | `3` | int Number of successful cronjobs to retain. |
 | cronJobPodAnnotations | object | `{}` |  |
 | deploymentAnnotations | object | `{}` |  |
 | envRenderSecret | object | `{}` | Sensible environment variables that will be rendered as new secret object This can be useful for auth tokens, etc Make sure not to commit sensitive values to git!! Better use AWS Secret manager (or any other) |

--- a/charts/cloudquery/templates/cronjob.yaml
+++ b/charts/cloudquery/templates/cronjob.yaml
@@ -6,8 +6,8 @@ metadata:
   {{- include "cloudquery.labels" . | nindent 4 }}
 spec:
   schedule: "{{ .Values.schedule }}"
-  successfulJobsHistoryLimit: "{{ .Values.cronJobLimit }}"
-  failedJobsHistoryLimit: "{{ .Values.cronJobFailedJobsLimit }}"
+  successfulJobsHistoryLimit: {{ .Values.cronJobLimit }}
+  failedJobsHistoryLimit: {{ .Values.cronJobFailedJobsLimit }}
   concurrencyPolicy: Forbid
   jobTemplate:
     metadata:

--- a/charts/cloudquery/templates/cronjob.yaml
+++ b/charts/cloudquery/templates/cronjob.yaml
@@ -6,6 +6,8 @@ metadata:
   {{- include "cloudquery.labels" . | nindent 4 }}
 spec:
   schedule: "{{ .Values.schedule }}"
+  successfulJobsHistoryLimit: "{{ .Values.cronJobLimit }}"
+  failedJobsHistoryLimit: "{{ .Values.cronJobFailedJobsLimit }}"
   concurrencyPolicy: Forbid
   jobTemplate:
     metadata:

--- a/charts/cloudquery/values.yaml
+++ b/charts/cloudquery/values.yaml
@@ -63,9 +63,9 @@ secretRef:
 # -- Schedule fetch time Every 6 hours.
 # More information at: https://crontab.guru/#0_0_*_*_*
 schedule: "0 */6 * * *"
-# -- int Number of successful cronjobs to retain.
+# -- (int) Number of successful cronjobs to retain.
 cronJobLimit: 3
-# -- int Number of failed cronjobs to retain.
+# -- (int) Number of failed cronjobs to retain.
 cronJobFailedJobsLimit: 1
 
 # -- CloudQuery cloudquery.yml content

--- a/charts/cloudquery/values.yaml
+++ b/charts/cloudquery/values.yaml
@@ -63,6 +63,8 @@ secretRef:
 # -- Schedule fetch time Every 6 hours.
 # More information at: https://crontab.guru/#0_0_*_*_*
 schedule: "0 */6 * * *"
+cronJobLimit: 3
+cronJobFailedJobsLimit: 1
 
 # -- CloudQuery cloudquery.yml content
 # @default -- The chart will use a default CloudQuery aws config

--- a/charts/cloudquery/values.yaml
+++ b/charts/cloudquery/values.yaml
@@ -63,7 +63,9 @@ secretRef:
 # -- Schedule fetch time Every 6 hours.
 # More information at: https://crontab.guru/#0_0_*_*_*
 schedule: "0 */6 * * *"
+# -- int Number of successful cronjobs to retain.
 cronJobLimit: 3
+# -- int Number of failed cronjobs to retain.
 cronJobFailedJobsLimit: 1
 
 # -- CloudQuery cloudquery.yml content


### PR DESCRIPTION
#### Description 📖 
Wanted to add the ability to configure the [cronJob history limits](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits) for the CloudQuery jobs running in kubernetes to have more control over retaining pod history, runtimes, logs, etc..

I chose names for the variables that hopefully reflect what the option is supposed to configure but I can't say I'm 100% in love with the names either 😬. Open to suggestions on better variable names.

#### Changes 📋 
- Added `cronJobLimit` and `cronJobFailedJobsLimit`
- Added defaults for the two new variables.
- Bumped chart version to `5.1.0` as I believe this to be a minor change
- Updated `README` using `make generate-docs`