### PR TITLE
feat: Implement tplConfig and Azure Workload Identity support

### DIFF
--- a/charts/cloudquery/Chart.yaml
+++ b/charts/cloudquery/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 12.0.0
+version: 12.1.0
 
 # -- This is the version number of the application being deployed.This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudquery/README.md
+++ b/charts/cloudquery/README.md
@@ -1,6 +1,6 @@
 # cloudquery
 
-![Version: 12.0.0](https://img.shields.io/badge/Version-12.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3](https://img.shields.io/badge/AppVersion-2.3-informational?style=flat-square)
+![Version: 12.1.0](https://img.shields.io/badge/Version-12.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3](https://img.shields.io/badge/AppVersion-2.3-informational?style=flat-square)
 
 Open source high performance data integration platform designed for security and infrastructure teams.
 
@@ -28,12 +28,14 @@ Kubernetes: `^1.8.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| admin.enabled | bool | `true` | Enable admin container useful for debugging into cloudquery |
 | config | string | The chart will use a default CloudQuery aws config | CloudQuery cloudquery.yml content |
-| containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]}}` | Container security context |
+| containerSecurityContext | object | See [values.yaml](./values.yaml) | Container security context |
 | cronJobAdditionalArgs | list | `[]` |  |
 | cronJobFailedJobsLimit | int | `1` | Number of failed cronjobs to retain. |
 | cronJobLimit | int | `3` | Number of successful cronjobs to retain. |
 | cronJobPodAnnotations | object | `{}` |  |
+| cronJobPodLabels | object | `{}` |  |
 | deploymentAnnotations | object | `{}` |  |
 | envRenderSecret | object | `{}` | Sensible environment variables that will be rendered as new secret object This can be useful for auth tokens, etc Make sure not to commit sensitive values to git!! Better use AWS Secret manager (or any other) |
 | fullnameOverride | string | `""` |  |
@@ -43,16 +45,16 @@ Kubernetes: `^1.8.0-0`
 | image.tag | string | `nil` | Overrides the image tag whose default is the chart appVersion |
 | labels | object | `{}` |  |
 | nameOverride | string | `""` | Partially override common.names.fullname template (will maintain the release name) |
-| promtail.config.clients[0].url | string | `"http://loki-gateway/loki/api/v1/push"` |  |
-| promtail.enabled | bool | `false` |  |
+| promtail | object | See [values.yaml](./values.yaml) | Promtail sub-chart configuration |
 | schedule | string | `"0 */6 * * *"` | Schedule fetch time Every 6 hours. More information at: https://crontab.guru/#0_0_*_*_* |
 | secretRef | string | `nil` | Reference to an external secret that contains sensible environment variables This option is useful to avoid store sensitive values in Git. You need to create the secret manually and reference it. If secretRef is used, the envRenderSecret parameter will be omitted (in case that it has content). |
 | securityContext | object | `{"fsGroup":1001}` | Pod security context |
-| serviceAccount | object | `{"annotations":{},"autoMount":false,"enabled":false,"name":""}` | Pod Service Account ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ |
 | serviceAccount.annotations | object | `{}` | Additional custom annotations for the ServiceAccount to associate an AWS IAM role with service-account you need to add the following annotations. For more info checkout: https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/ROLE |
 | serviceAccount.autoMount | bool | `false` | Auto-mount the service account token in the pod |
 | serviceAccount.enabled | bool | `false` | Enable service account (Note: Service Account will only be automatically created if `serviceAccount.name` is not set) |
+| serviceAccount.labels | object | `{}` | Additional custom label for the ServiceAccount |
 | serviceAccount.name | string | `""` | Name of an already existing service account. Setting this value disables the automatic service account creation |
+| tplConfig | bool | `false` | Pass the configuration directives and envRenderSecret through Helm's templating engine. # ref: https://helm.sh/docs/developing_charts/#using-the-tpl-function |
 | volumeMounts | string | `nil` |  |
 | volumes | string | `nil` |  |
 

--- a/charts/cloudquery/templates/admin-deployment.yaml
+++ b/charts/cloudquery/templates/admin-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.admin.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,11 +31,11 @@ spec:
           env:
           - name: CQ_INSTALL_SRC
             value: "{{ .Values.cqInstallSrc | default "HELM" }}"
-          envFrom:          
+          envFrom:
           - secretRef:
               {{- if .Values.secretRef}}
-              name: {{ .Values.secretRef }}              
-              {{- else}}              
+              name: {{ .Values.secretRef }}
+              {{- else}}
               name: {{ include "cloudquery.fullname" . }}-secret
               {{- end}}
           image: "{{ include "cloudquery.image" . }}"
@@ -64,3 +65,4 @@ spec:
           items:
           - key: cloudquery.yml
             path: cloudquery.yml
+{{- end }}

--- a/charts/cloudquery/templates/configmap.yaml
+++ b/charts/cloudquery/templates/configmap.yaml
@@ -6,4 +6,8 @@ metadata:
   {{- include "cloudquery.labels" . | nindent 4 }}
 data:
   cloudquery.yml: |-
+  {{- if .Values.tplConfig }}
+  {{- tpl .Values.config $ | nindent 4 }}
+  {{- else }}
   {{- .Values.config | nindent 4 }}
+  {{- end }}

--- a/charts/cloudquery/templates/cronjob.yaml
+++ b/charts/cloudquery/templates/cronjob.yaml
@@ -19,10 +19,11 @@ spec:
         metadata:
           labels:
           {{- include "cloudquery.labels" . | nindent 12 }}
+          {{- toYaml .Values.cronJobPodLabels | nindent 12 }}
           {{- if .Values.cronJobPodAnnotations }}
           annotations:
           {{- toYaml .Values.cronJobPodAnnotations | nindent 12 }}
-          {{- end}}
+          {{- end }}
         spec:
           {{- if .Values.serviceAccount.enabled }}
           serviceAccountName: {{ include "cloudquery.serviceAccountName" . }}
@@ -41,7 +42,7 @@ spec:
                   {{- if .Values.secretRef}}
                   name: {{ .Values.secretRef }}
                   {{- else}}
-                  name: {{ include "cloudquery.fullname" . }}-secret                
+                  name: {{ include "cloudquery.fullname" . }}-secret
                   {{- end}}
               image: "{{ include "cloudquery.image" . }}"
               imagePullPolicy: Always

--- a/charts/cloudquery/templates/cronjob.yaml
+++ b/charts/cloudquery/templates/cronjob.yaml
@@ -19,7 +19,9 @@ spec:
         metadata:
           labels:
           {{- include "cloudquery.labels" . | nindent 12 }}
+          {{- if .Values.cronJobPodLabels }}
           {{- toYaml .Values.cronJobPodLabels | nindent 12 }}
+          {{- end }}
           {{- if .Values.cronJobPodAnnotations }}
           annotations:
           {{- toYaml .Values.cronJobPodAnnotations | nindent 12 }}

--- a/charts/cloudquery/templates/secret.yaml
+++ b/charts/cloudquery/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.secretRef}}
+{{- if not .Values.secretRef }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,6 +8,10 @@ metadata:
 type: Opaque
 data:
 {{- range $k, $v := .Values.envRenderSecret }}
+  {{- if .Values.tplConfig }}
+  {{ $k }}: {{ tpl $v $ | b64enc | quote }}
+  {{- else }}
   {{ $k }}: {{ $v | b64enc | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/cloudquery/templates/serviceaccount.yaml
+++ b/charts/cloudquery/templates/serviceaccount.yaml
@@ -1,10 +1,16 @@
 {{- if .Values.serviceAccount.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
+{{- with .Values.serviceAccount.autoMount }}
+automountServiceAccountToken: {{ . }}
+{{- end }}
 metadata:
   name: {{ include "cloudquery.serviceAccountName" . }}
   labels:
     {{- include "cloudquery.labels" . | nindent 4 }}
+    {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/cloudquery/values.yaml
+++ b/charts/cloudquery/values.yaml
@@ -14,13 +14,13 @@ securityContext:
   fsGroup: 1001
 
 # -- Container security context
+# @default -- See [values.yaml](./values.yaml)
 containerSecurityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
       - all
 
-# -- Pod Service Account
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 serviceAccount:
   # -- Enable service account (Note: Service Account will only be automatically created if `serviceAccount.name` is not set)
@@ -33,6 +33,13 @@ serviceAccount:
   # to associate an AWS IAM role with service-account you need to add the following annotations. For more info checkout: https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html
   # eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/ROLE
   annotations: {}
+  # -- Additional custom label for the ServiceAccount
+  labels: {}
+
+admin:
+  # -- Enable admin container
+  # useful for debugging into cloudquery
+  enabled: true
 
 # -- Sensible environment variables that will be rendered as new secret object
 # This can be useful for auth tokens, etc
@@ -54,6 +61,10 @@ envRenderSecret: {}
 # AZURE_CLIENT_SECRET: ""
 
 # For any other plugins visit https://cloudquery.io/docs/plugins/sources
+
+# -- Pass the configuration directives and envRenderSecret through Helm's templating engine.
+## ref: https://helm.sh/docs/developing_charts/#using-the-tpl-function
+tplConfig: false
 
 # -- Reference to an external secret that contains sensible environment variables
 # This option is useful to avoid store sensitive values in Git. You need to create the secret manually and reference it.
@@ -98,6 +109,8 @@ volumeMounts:
 #     memory: 1024Mi
 #     cpu: 1000m
 
+# -- Promtail sub-chart configuration
+# @default -- See [values.yaml](./values.yaml)
 promtail:
   enabled: false
   config:
@@ -112,6 +125,9 @@ deploymentAnnotations: {}
 
 # Optional. CronJob Pod annotations.
 cronJobPodAnnotations: {}
+
+# Optional. CronJob Pod labels.
+cronJobPodLabels: {}
 
 # Optional. Additional CLI arguments to pass to the scheduled sync job (e.g. setting log format)
 # More information at: https://www.cloudquery.io/docs/reference/cli/cloudquery


### PR DESCRIPTION
Hi,

I would like to add some improvements to the helm chart. On request, I can split them as well.

1. I added podLabels and serviceAccount labels, since unlike AWS IRSA, Azure Workload Identity depend on them
2. I add a toggle to conditionally enable the admin deployment, since it feels like the deployment is only required for debugging scnarios.
3. I added a toggle to pass config and envRenderSecret trough helm tpl function. This allow umbrella charts to aggregate configuration. In this scenario, I could re-use the [postgresql](https://github.com/bitnami/charts/blob/f4f18c3de0c4103ea2f054d9e2afce1d9ac6919a/bitnami/postgresql/values.yaml#L4-L32) chart values in the cloudquery chart.
4. Fixed the `serviceAccount.autoMount` toggle