### PR TITLE
fix: Fix `tplConfig` scope in `secret.yaml`

### DIFF
--- a/charts/cloudquery/Chart.yaml
+++ b/charts/cloudquery/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 14.1.3
+version: 14.1.4
 
 # -- This is the version number of the application being deployed.This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudquery/README.md
+++ b/charts/cloudquery/README.md
@@ -1,6 +1,6 @@
 # cloudquery
 
-![Version: 14.1.3](https://img.shields.io/badge/Version-14.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4](https://img.shields.io/badge/AppVersion-2.4-informational?style=flat-square)
+![Version: 14.1.4](https://img.shields.io/badge/Version-14.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4](https://img.shields.io/badge/AppVersion-2.4-informational?style=flat-square)
 
 Open source high performance data integration platform designed for security and infrastructure teams.
 

--- a/charts/cloudquery/templates/secret.yaml
+++ b/charts/cloudquery/templates/secret.yaml
@@ -7,8 +7,9 @@ metadata:
   {{- include "cloudquery.labels" . | nindent 4 }}
 type: Opaque
 data:
+{{- $tplConfig  := .Values.tplConfig -}}
 {{- range $k, $v := .Values.envRenderSecret }}
-  {{- if .Values.tplConfig }}
+  {{- if $tplConfig }}
   {{ $k }}: {{ tpl $v $ | b64enc | quote }}
   {{- else }}
   {{ $k }}: {{ $v | b64enc | quote }}


### PR DESCRIPTION
Fixes https://github.com/cloudquery/helm-charts/issues/278

Follow up to https://github.com/cloudquery/helm-charts/pull/263.

Since we range over `.Values.envRenderSecret` we need to extract the `tplConfig` before, otherwise we're at the wrong scope