### PR TITLE
chore(issue-templates): Remove `needs-triage` label from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: 🐛 Bug Report
 description: If something isn't working as expected 🤔
 title: "bug: <title>"
-labels: [bug, needs-triage]
+labels: [bug]
 body:
   - type: checkboxes
     attributes:


### PR DESCRIPTION
Same as https://github.com/cloudquery/cloudquery/pull/10276