### PR TITLE
fix: Support existing serviceAccount without overwriting

### DIFF
--- a/charts/cloudquery/Chart.yaml
+++ b/charts/cloudquery/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 25.0.9
+version: 25.0.10
 
 # -- This is the version number of the application being deployed.This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cloudquery/README.md
+++ b/charts/cloudquery/README.md
@@ -1,6 +1,6 @@
 # cloudquery
 
-![Version: 25.0.9](https://img.shields.io/badge/Version-25.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.12](https://img.shields.io/badge/AppVersion-3.12-informational?style=flat-square)
+![Version: 25.0.10](https://img.shields.io/badge/Version-25.0.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.12](https://img.shields.io/badge/AppVersion-3.12-informational?style=flat-square)
 
 Open source high performance data integration platform designed for security and infrastructure teams.
 

--- a/charts/cloudquery/templates/admin-deployment.yaml
+++ b/charts/cloudquery/templates/admin-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       {{- toYaml .Values.deploymentAnnotations | nindent 8 }}
       {{- end }}
     spec:
-      {{- if .Values.serviceAccount.enabled }}
+      {{- if ne (include "cloudquery.serviceAccountName" .) "default" }}
       serviceAccountName: {{ include "cloudquery.serviceAccountName" . }}
       {{- end }}
       {{- if .Values.securityContext }}

--- a/charts/cloudquery/templates/cronjob.yaml
+++ b/charts/cloudquery/templates/cronjob.yaml
@@ -27,7 +27,7 @@ spec:
           {{- toYaml .Values.cronJobPodAnnotations | nindent 12 }}
           {{- end }}
         spec:
-          {{- if .Values.serviceAccount.enabled }}
+          {{- if ne (include "cloudquery.serviceAccountName" .) "default" }}
           serviceAccountName: {{ include "cloudquery.serviceAccountName" . }}
           {{- end }}
           {{- if .Values.securityContext }}

--- a/charts/cloudquery/templates/job.yaml
+++ b/charts/cloudquery/templates/job.yaml
@@ -19,7 +19,7 @@ spec:
       {{- toYaml .Values.cronJobPodAnnotations | nindent 12 }}
       {{- end }}
     spec:
-      {{- if .Values.serviceAccount.enabled }}
+      {{- if ne (include "cloudquery.serviceAccountName" .) "default" }}
       serviceAccountName: {{ include "cloudquery.serviceAccountName" . }}
       {{- end }}
       {{- if .Values.securityContext }}


### PR DESCRIPTION
When adopting pre-existing serviceAccounts, the previous evaluation would result in either no service account being included or the existing service account being overridden (if you set `serviceAccount.enabled = "true"`).

This modification enables you to use existing `serviceAccounts` safely (for example, if you created one with `eksctl`).