### PR TITLE
chore: Ignore platform helm chart changes in workflow

### DIFF
--- a/.github/workflows/deps_bump_versions.yml
+++ b/.github/workflows/deps_bump_versions.yml
@@ -2,6 +2,8 @@ name: Bumps versions and docs for dependencies updates
 
 on:
   pull_request_target:
+    paths-ignore:
+      - 'charts/platform/**'
     types: [opened, reopened]
 
 jobs:


### PR DESCRIPTION
We intend to introduce release-please to support the platform helm chart release, as such we do not need to trigger the bump command for platform-only changes.
