### PR TITLE
chore: Use a personal access token when updating docs

### DIFF
--- a/.github/workflows/auto_update_docs.yml
+++ b/.github/workflows/auto_update_docs.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_CQ_BOT }}
 
       - name: Update Docs
         run: |


### PR DESCRIPTION
Otherwise the new commit doesn't trigger any workflows