### PR TITLE
chore: Add a `lint-pr` step

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -44,7 +44,12 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1
 
-      - name: Run chart-testing (lint)
+      - name: Run chart-testing (lint PR)
+        if: ${{ !startsWith(github.head_ref || '', 'release-please-') }}
+        run: make lint-pr
+
+      - name: Run chart-testing (lint release)
+        if: ${{ startsWith(github.head_ref || '', 'release-please-') }}
         run: make lint
 
       - name: Run chart-testing (test)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 lint:
 	ct lint --config=ct.yaml
 
+.PHONY: lint-pr
+lint-pr:
+	ct lint --check-version-increment=false --config=ct.yaml
+
 .PHONY: generate-docs
 generate-docs:
 	helm-docs


### PR DESCRIPTION
This will call the `ct lint` but will skip any version increment checks. This is beacuse the version incrementing only happens as part of the release PR.
