### PR TITLE
chore: Add `cloudquery-backend` codeowners of platform helm chart

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,3 @@
-*       @cloudquery/cloudquery-framework 
+*       @cloudquery/cloudquery-framework
+
+/charts/platform @cloudquery/cloudquery-backend


### PR DESCRIPTION
This will allow the `cloudquery-backend` team to merge platform helm changes.