### PR TITLE
fix!: Update cloud dependency to `v0.23.0`

### DIFF
--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
   - name: yevgenypats
     email: yp@cloudquery.io
 version: 0.2.3
-appVersion: 0.22.0
+appVersion: 0.23.0
 annotations:
   artifacthub.io/license: MPL-2.0
   artifacthub.io/links: |

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 Helm chart for installing the CloudQuery self-hosted platform
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.21.1](https://img.shields.io/badge/AppVersion-0.21.1-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.23.0](https://img.shields.io/badge/AppVersion-0.23.0-informational?style=flat-square)
 
 ## Quickstart
 
@@ -212,6 +212,7 @@ Kubernetes: `^1.8.0-0`
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
+| jwtPrivateKey | string | `""` | JWT private key for the self-hosted platform - if not provided, a new key will be generated |
 | livenessProbe.httpGet.path | string | `"/"` |  |
 | livenessProbe.httpGet.port | string | `"api"` |  |
 | livenessProbe.periodSeconds | int | `60` |  |

--- a/charts/platform/templates/deployments.yaml
+++ b/charts/platform/templates/deployments.yaml
@@ -28,27 +28,6 @@ spec:
       serviceAccountName: {{ include "platform.serviceAccount" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      initContainers:
-        - name: {{ .Chart.Name }}-init
-          image: "{{ include "platform.image" . }}"
-          command: [ "/backend/localadmin", "init" ]
-          env:
-            - name: CQAPI_DB_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "platform.fullName" . }}-secrets
-                  key: postgresqlDSN
-            - name: CQAPI_LOCAL_AES_KEY_FILE
-              value: /shared/encrypted_aes_key.bin
-            - name: CQAPI_LOCAL_JWT_PRIVATE_KEY_FILE
-              value: /etc/jwt/jwt-private-key.pem
-          volumeMounts:
-            - name: jwt-private-key
-              mountPath: /etc/jwt/jwt-private-key.pem
-              subPath: jwtPrivateKey
-              readOnly: true
-            - name: shared-data
-              mountPath: /shared
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -56,8 +35,6 @@ spec:
           image: "{{ include "platform.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            - name: CQAPI_LOCAL_AES_KEY_FILE
-              value: /shared/encrypted_aes_key.bin
             {{- if .Values.activationKey }}
             - name: CQAPI_LOCAL_ACTIVATION_KEY
               valueFrom:
@@ -75,8 +52,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "platform.fullName" . }}-secrets
                   key: clickhouseDSN
-            - name: CQAPI_LOCAL_JWT_PRIVATE_KEY_FILE
-              value: /etc/jwt/jwt-private-key.pem
+            - name: CQAPI_LOCAL_JWT_PRIVATE_KEY
+              valueFrom:
+                  secretKeyRef:
+                    name: {{ include "platform.fullName" . }}-secrets
+                    key: jwtPrivateKey
             - name: CQAPI_REDIS_ADDR
               value: redis://{{ .Release.Name }}-redis-master.{{ .Release.Namespace }}.svc.cluster.local:6379
           ports:
@@ -102,21 +82,10 @@ spec:
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-            - name: jwt-private-key
-              mountPath: /etc/jwt/jwt-private-key.pem
-              subPath: jwtPrivateKey
-              readOnly: true
-            - name: shared-data
-              mountPath: /shared
       volumes:
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
-        - name: jwt-private-key
-          secret:
-            secretName: {{ include "platform.fullName" . }}-secrets
-        - name: shared-data
-          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/platform/templates/secrets.yaml
+++ b/charts/platform/templates/secrets.yaml
@@ -10,4 +10,4 @@ data:
   {{- end }}
   postgresqlDSN: {{ required "A valid postgres DSN is required" .Values.externalDependencies.postgresql_dsn | b64enc }}
   clickhouseDSN: {{ required "A valid clickhouse DSN is required" .Values.externalDependencies.clickhouse_dsn | b64enc }}
-  jwtPrivateKey: {{ genPrivateKey "rsa" | b64enc }}
+  jwtPrivateKey: {{ .Values.jwtPrivateKey | default (genPrivateKey "rsa") | b64enc }}

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -76,6 +76,9 @@ volumeMounts: []
 # -- Activation key for the self-hosted platform
 activationKey: ""
 
+# -- JWT private key for the self-hosted platform - if not provided, a new key will be generated
+jwtPrivateKey: ""
+
 externalDependencies:
   # -- Required: The DSN for the Postgres database
   postgresql_dsn: ""


### PR DESCRIPTION
This update no longer needs the init container, so removing this and setting the correct environment variables.

Refs: https://github.com/cloudquery/helm-charts/pull/517