### PR TITLE
chore: Fix python version

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.13.1
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1


### PR DESCRIPTION
Try updating the Python version - the one we have configured is no [longer supported](https://github.com/cloudquery/helm-charts/actions/runs/12843508016/job/35815536639?pr=552)
