### PR TITLE
fix: Add CLICKHOUSE_DATABASE back to config

### DIFF
--- a/charts/platform/config/otel-config.yaml
+++ b/charts/platform/config/otel-config.yaml
@@ -33,7 +33,7 @@ exporters:
   nop:
   clickhouse:
     endpoint: ${env:CLICKHOUSE_DSN}
-    # database: ${env:CLICKHOUSE_DATABASE}
+    database: ${env:CLICKHOUSE_DATABASE}
     create_schema: true
     ttl: 0
     timeout: 10s

--- a/charts/platform/templates/otelcollector.yaml
+++ b/charts/platform/templates/otelcollector.yaml
@@ -38,6 +38,9 @@ spec:
                   name: {{ include "platform.fullName" . }}-secrets
                   {{- end }}
                   key: clickhouseDSN
+          env:
+            - name: CLICKHOUSE_DATABASE
+              value: "assets"
           ports:
             {{- range .Values.otelCollector.service.ports }}
             - name: {{ .name }}

--- a/charts/platform/templates/otelcollector.yaml
+++ b/charts/platform/templates/otelcollector.yaml
@@ -40,7 +40,7 @@ spec:
                   key: clickhouseDSN
           env:
             - name: CLICKHOUSE_DATABASE
-              value: "assets"
+              value: "assets" # TODO: Make this configurable
           ports:
             {{- range .Values.otelCollector.service.ports }}
             - name: {{ .name }}


### PR DESCRIPTION
This needs to be configurable and derivable from the main ClickHouse DSN (as I think otel and data live in the same DB/schema).

I will fix the todo in a follow-up so that we can unblock the failing PRs.