### PR TITLE
fix: Cleanup extra env variable

### DIFF
--- a/charts/platform/templates/otelcollector.yaml
+++ b/charts/platform/templates/otelcollector.yaml
@@ -38,7 +38,6 @@ spec:
                   name: {{ include "platform.fullName" . }}-secrets
                   {{- end }}
                   key: clickhouseDSN
-          env:
             - name: CLICKHOUSE_DATABASE
               value: "assets" # TODO: Make this configurable
           ports:


### PR DESCRIPTION
`env` section already declared, this isn't needed.