### PR TITLE
fix: Make otel DB configurable

### DIFF
--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -2,7 +2,7 @@
 
 Helm chart for installing the CloudQuery self-hosted platform
 
-![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.39.2](https://img.shields.io/badge/AppVersion-0.39.2-informational?style=flat-square)
+![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.0](https://img.shields.io/badge/AppVersion-0.40.0-informational?style=flat-square)
 
 ## Quickstart
 
@@ -220,7 +220,8 @@ Kubernetes: `^1.8.0-0`
 | livenessProbe.httpGet.port | string | `"api"` |  |
 | livenessProbe.periodSeconds | int | `60` |  |
 | nameOverride | string | `""` | Override the default name |
-| otelCollector | object | `{"enabled":true,"image":{"pullPolicy":"IfNotPresent","repository":"otel/opentelemetry-collector-contrib","tag":"0.113.0"},"resources":{},"service":{"ports":[{"name":"otlp-grpc","port":4317,"protocol":"TCP","targetPort":4317},{"name":"otlp-http","port":4318,"protocol":"TCP","targetPort":4318}],"type":"ClusterIP"}}` | OTEL Collector configuration |
+| otelCollector | object | `{"database":"default","enabled":true,"image":{"pullPolicy":"IfNotPresent","repository":"otel/opentelemetry-collector-contrib","tag":"0.113.0"},"resources":{},"service":{"ports":[{"name":"otlp-grpc","port":4317,"protocol":"TCP","targetPort":4317},{"name":"otlp-http","port":4318,"protocol":"TCP","targetPort":4318}],"type":"ClusterIP"}}` | OTEL Collector configuration |
+| otelCollector.database | string | `"default"` | Optional. The database to use for the ClickHouse exporter (should match the ClickHouse DSN) |
 | otelCollector.enabled | bool | `true` | Optional. Enable the OTEL Collector. |
 | podAnnotations | object | `{}` | Addition pod annotations |
 | podLabels | object | `{}` | Addition pod labels |

--- a/charts/platform/ci/test-values.yaml
+++ b/charts/platform/ci/test-values.yaml
@@ -2,3 +2,5 @@ externalDependencies:
   # 172.17.0.1 is the default gateway for the docker0 bridge network
   postgresql_dsn: "postgres://postgres:pass@172.17.0.1:5432/postgres?sslmode=disable"
   clickhouse_dsn: "clickhouse://user:pass@172.17.0.1:9000/assets"
+otelCollector:
+  database: "assets"

--- a/charts/platform/templates/otelcollector.yaml
+++ b/charts/platform/templates/otelcollector.yaml
@@ -39,7 +39,7 @@ spec:
                   {{- end }}
                   key: clickhouseDSN
             - name: CLICKHOUSE_DATABASE
-              value: "assets" # TODO: Make this configurable
+              value: {{ .Values.otelCollector.database }}
           ports:
             {{- range .Values.otelCollector.service.ports }}
             - name: {{ .name }}

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -113,6 +113,9 @@ otelCollector:
     tag: "0.113.0"
     pullPolicy: IfNotPresent
 
+  # -- Optional. The database to use for the ClickHouse exporter (should match the ClickHouse DSN)
+  database: "default"
+
   resources:
     {}
     # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Even though we are supplying a full DSN (including the database) the CLICKHOUSE_DATABASE variable also needs to be defined.

I've set this to be `default` (by default) which corresponds to a CH database that has been created with no dedicated database (e.g. assets).

We might also look into parsing the DSN in Helm (and CloudFormation) to deduce the value for the CLICKHOUSE_DATABASE.
