### PR TITLE
feat: Support NLB deployment via Helm

### DIFF
--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -192,11 +192,8 @@ Kubernetes: `^1.8.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| activationKey | string | `""` | Activation key for the self-hosted platform |
 | containerSecurityContext | object | `{}` | Specify the container-level security context |
 | debug.enabled | bool | `false` | Optional. Enable debug mode. |
-| externalDependencies.clickhouse_dsn | string | `""` | Required: The DSN for the ClickHouse database |
-| externalDependencies.postgresql_dsn | string | `""` | Required: The DSN for the Postgres database |
 | externalSecrets | object | `{"cloudquerySecretsKey":"","enabled":false,"externalSecretsRoleARN":"","region":""}` | External secrets configuration |
 | externalSecrets.cloudquerySecretsKey | string | `""` | Required: The AWS secret key for the Postgres DSN |
 | externalSecrets.enabled | bool | `false` | Optional. Enable external secrets. |
@@ -213,7 +210,6 @@ Kubernetes: `^1.8.0-0`
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
-| jwtPrivateKey | string | `""` | JWT private key for the self-hosted platform - if not provided, a new key will be generated |
 | letsEncrypt.email | string | `""` | Required: The email address to use for Let's Encrypt |
 | letsEncrypt.enabled | bool | `false` | Optional. Enable Let's Encrypt. |
 | livenessProbe.httpGet.path | string | `"/"` |  |
@@ -223,6 +219,9 @@ Kubernetes: `^1.8.0-0`
 | otelCollector | object | `{"database":"default","enabled":true,"image":{"pullPolicy":"IfNotPresent","repository":"otel/opentelemetry-collector-contrib","tag":"0.113.0"},"resources":{},"service":{"ports":[{"name":"otlp-grpc","port":4317,"protocol":"TCP","targetPort":4317},{"name":"otlp-http","port":4318,"protocol":"TCP","targetPort":4318}],"type":"ClusterIP"}}` | OTEL Collector configuration |
 | otelCollector.database | string | `"default"` | Optional. The database to use for the ClickHouse exporter (should match the ClickHouse DSN) |
 | otelCollector.enabled | bool | `true` | Optional. Enable the OTEL Collector. |
+| platformSecrets | object | `{"jwtPrivateKeyRef":"","secretRef":"cq-platform-secrets"}` | Platform secrets configuration |
+| platformSecrets.jwtPrivateKeyRef | string | `""` | JWT private key reference for the self-hosted platform - if not provided, a new key will be generated |
+| platformSecrets.secretRef | string | `"cq-platform-secrets"` | Required: The secret reference to use for the user-supplied platform secrets |
 | podAnnotations | object | `{}` | Addition pod annotations |
 | podLabels | object | `{}` | Addition pod labels |
 | podSecurityContext | object | `{}` | Specify the pod-level security context |
@@ -232,7 +231,7 @@ Kubernetes: `^1.8.0-0`
 | replicaCount | int | `1` | The number of replicas to deploy |
 | resources | object | `{}` | Deployment resources |
 | scheduler | object | `{"address":"scheduler-cloudquery-operator:3001"}` | Specify the scheduler configuration |
-| service | object | `{"apiPort":4444,"apiType":"ClusterIP","proxyPort":3000,"proxyType":"ClusterIP","storagePort":4445,"storageType":"ClusterIP","uiPort":3001,"uiType":"ClusterIP"}` | Specify the ports the container exposes |
+| service | object | `{"annotations":{},"port":3000,"targetPort":3000,"type":"ClusterIP"}` | Specify the ports the container exposes |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.automount | bool | `true` |  |
 | serviceAccount.create | bool | `false` |  |

--- a/charts/platform/templates/NOTES.txt
+++ b/charts/platform/templates/NOTES.txt
@@ -1,6 +1,6 @@
 # Pod Access
 
-The CloudQuery Platform UI can be accessed directly via the pod on port {{ .Values.service.proxyPort }}.
+The CloudQuery Platform UI can be accessed directly via the pod on port {{ .Values.service.targetPort }}.
 
 1. Setup port forwarding to access the UI by doing the following:
 

--- a/charts/platform/templates/_helpers.tpl
+++ b/charts/platform/templates/_helpers.tpl
@@ -67,3 +67,25 @@ Return the image to use depending on the AppVersion and image tag defined
 {{- define "platform.image" -}}
 {{ .Values.image.repository }}:{{ if .Values.image.tag }}{{ .Values.image.tag }}{{ else }}v{{ .Chart.AppVersion }}{{ end }}
 {{- end }}
+
+{{/*
+Get the appropriate secret reference name based on whether external secrets is enabled
+*/}}
+{{- define "platform.secretRef" -}}
+{{- if index .Values "externalSecrets" "enabled" -}}
+{{- include "platform.fullName" . }}-external-secrets
+{{- else -}}
+{{- .Values.platformSecrets.secretRef -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the appropriate secret reference name based on whether external secrets is enabled
+*/}}
+{{- define "platform.jwtPrivateKeyRef" -}}
+{{- if index .Values "platformSecrets" "jwtPrivateKeyRef" -}}
+{{- .Values.platformSecrets.jwtPrivateKeyRef -}}
+{{- else -}}
+{{- include "platform.fullName" . }}-jwt-private-key
+{{- end -}}
+{{- end -}}

--- a/charts/platform/templates/deployments.yaml
+++ b/charts/platform/templates/deployments.yaml
@@ -38,47 +38,27 @@ spec:
           image: "{{ include "platform.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            {{- if index .Values "externalSecrets" "enabled" }}
             - name: CQAPI_DB_DSN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "platform.fullName" . }}-external-secrets
+                  name: {{ include "platform.secretRef" . }}
                   key: postgresqlDSN
             - name: CQAPI_LOCAL_ACTIVATION_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "platform.fullName" . }}-external-secrets
+                  name: {{ include "platform.secretRef" . }}
                   key: activationKey
             - name: CQAPI_WAREHOUSE_CLICKHOUSE_DSN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "platform.fullName" . }}-external-secrets
+                  name: {{ include "platform.secretRef" . }}
                   key: clickhouseDSN
-            {{- else }}
-            - name: CQAPI_DB_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "platform.fullName" . }}-secrets
-                  key: postgresqlDSN
-            {{- if .Values.activationKey }}
-            - name: CQAPI_LOCAL_ACTIVATION_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "platform.fullName" . }}-secrets
-                  key: activationKey
-            {{- end }}
-            - name: CQAPI_WAREHOUSE_CLICKHOUSE_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "platform.fullName" . }}-secrets
-                  key: clickhouseDSN
-            {{- end }}
             - name: CQAPI_LOCAL_AES_KEY_FILE
               value: "/shared/encrypted_aes_key.bin"
             - name: CQAPI_LOCAL_JWT_PRIVATE_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "platform.fullName" . }}-secrets
+                  name: {{ include "platform.jwtPrivateKeyRef" . }}
                   key: jwtPrivateKey
             # todo: figure out if we want this to go through the proxy / update once resolver is fixed
             - name: CQAPI_STORAGE_LOCAL_RELEASE_BASE_URL

--- a/charts/platform/templates/deployments.yaml
+++ b/charts/platform/templates/deployments.yaml
@@ -4,11 +4,13 @@ metadata:
   name: {{ include "platform.fullName" . }}
   labels:
     {{- include "platform.labels" . | nindent 4 }}
+    app.kubernetes.io/component: application
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       {{- include "platform.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: application
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -17,6 +19,7 @@ spec:
       {{- end }}
       labels:
         {{- include "platform.labels" . | nindent 8 }}
+        app.kubernetes.io/component: application
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -79,25 +82,25 @@ spec:
                   key: jwtPrivateKey
             # todo: figure out if we want this to go through the proxy / update once resolver is fixed
             - name: CQAPI_STORAGE_LOCAL_RELEASE_BASE_URL
-              value: "http://{{ include "platform.fullName" . }}.{{ .Release.Namespace }}:{{ .Values.service.proxyPort }}/storage/development/files"
+              value: "http://{{ include "platform.fullName" . }}.{{ .Release.Namespace }}:{{ .Values.service.targetPort }}/storage/development/files"
             {{- if .Values.scheduler.address }}
             - name: CQAPI_MANAGEDSYNC_BACKEND_URL
               value: "{{ .Values.scheduler.address }}"
             - name: CQAPI_MANAGEDSYNC_PLATFORM_URL
-              value: "http://{{ include "platform.fullName" . }}.{{ .Release.Namespace }}:{{ .Values.service.proxyPort }}/api"
+              value: "http://{{ include "platform.fullName" . }}.{{ .Release.Namespace }}:{{ .Values.service.targetPort }}/api"
             {{- end}}
           ports:
             - name: proxy
-              containerPort: {{ .Values.service.proxyPort }}
+              containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
             - name: ui
-              containerPort: {{ .Values.service.uiPort }}
+              containerPort: 3001
               protocol: TCP
             - name: api
-              containerPort: {{ .Values.service.apiPort }}
+              containerPort: 4444
               protocol: TCP
             - name: storage
-              containerPort: {{ .Values.service.storagePort }}
+              containerPort: 4445
               protocol: TCP
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}

--- a/charts/platform/templates/ingress.yaml
+++ b/charts/platform/templates/ingress.yaml
@@ -46,7 +46,7 @@ spec:
               service:
                 name: {{ include "platform.fullName" $ }}
                 port:
-                  number: {{ $.Values.service.proxyPort }}
+                  number: {{ $.Values.service.targetPort }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/platform/templates/otelcollector.yaml
+++ b/charts/platform/templates/otelcollector.yaml
@@ -32,11 +32,7 @@ spec:
             - name: CLICKHOUSE_DSN
               valueFrom:
                 secretKeyRef:
-                  {{- if index .Values "externalSecrets" "enabled" }}
-                  name: {{ include "platform.fullName" . }}-external-secrets
-                  {{- else }}
-                  name: {{ include "platform.fullName" . }}-secrets
-                  {{- end }}
+                  name: {{ include "platform.secretRef" . }}
                   key: clickhouseDSN
             - name: CLICKHOUSE_DATABASE
               value: {{ .Values.otelCollector.database }}

--- a/charts/platform/templates/secrets.yaml
+++ b/charts/platform/templates/secrets.yaml
@@ -1,19 +1,14 @@
+{{- if not (index .Values "platformSecrets" "jwtPrivateKeyRef") }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "platform.fullName" . }}-secrets
+  name: {{ include "platform.fullName" . }}-jwt-private-key
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  {{- if not (index .Values "externalSecrets" "enabled") }}
-  {{- if .Values.activationKey }}
-  activationKey: {{ .Values.activationKey | b64enc }}
-  {{- end }}
-  postgresqlDSN: {{ required "A valid postgres DSN is required" .Values.externalDependencies.postgresql_dsn | b64enc }}
-  clickhouseDSN: {{ required "A valid clickhouse DSN is required" .Values.externalDependencies.clickhouse_dsn | b64enc }}
-  {{- end }}
-  jwtPrivateKey: {{ .Values.jwtPrivateKey | default (genPrivateKey "rsa") | b64enc }}
+  jwtPrivateKey: {{ (genPrivateKey "rsa") | b64enc }}
 ---
+{{- end }}
 {{- if index .Values "externalSecrets" "enabled" }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret

--- a/charts/platform/templates/services.yaml
+++ b/charts/platform/templates/services.yaml
@@ -2,17 +2,22 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "platform.fullName" . }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "platform.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.service.proxyType }}
+  type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.proxyPort }}
+    - port: {{ .Values.service.port }}
       targetPort: proxy
       protocol: TCP
       name: proxy
   selector:
     {{- include "platform.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: application
 ---
 {{- if .Values.otelCollector.enabled }}
 apiVersion: v1

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -33,14 +33,10 @@ containerSecurityContext: {}
 
 # -- Specify the ports the container exposes
 service:
-  proxyType: ClusterIP
-  proxyPort: 3000
-  uiType: ClusterIP
-  uiPort: 3001
-  apiType: ClusterIP
-  apiPort: 4444
-  storageType: ClusterIP
-  storagePort: 4445
+  type: ClusterIP
+  port: 3000
+  targetPort: 3000
+  annotations: {}
 
 # -- Specify the scheduler configuration
 scheduler:

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -74,11 +74,13 @@ volumes: []
 # -- Additional volumeMounts on the output Deployment definition.
 volumeMounts: []
 
-# -- Activation key for the self-hosted platform
-activationKey: ""
+# -- Platform secrets configuration
+platformSecrets:
+  # -- Required: The secret reference to use for the user-supplied platform secrets
+  secretRef: "cq-platform-secrets"
 
-# -- JWT private key for the self-hosted platform - if not provided, a new key will be generated
-jwtPrivateKey: ""
+  # -- JWT private key reference for the self-hosted platform - if not provided, a new key will be generated
+  jwtPrivateKeyRef: ""
 
 # -- External secrets configuration
 externalSecrets:
@@ -90,13 +92,6 @@ externalSecrets:
   cloudquerySecretsKey: ""
   # -- Required: The AWS role ARN to assume when fetching the secrets
   externalSecretsRoleARN: ""
-
-externalDependencies:
-  # -- Required: The DSN for the Postgres database
-  postgresql_dsn: ""
-
-  # -- Required: The DSN for the ClickHouse database
-  clickhouse_dsn: ""
 
 letsEncrypt:
   # -- Optional. Enable Let's Encrypt.


### PR DESCRIPTION
Adds support for creating NLBs with an existing ACM certificate. In addition, secrets are now expected to be pre-created by the user. This is preferred approach with Helm since anything passed as a value can be viewed in plain text via `helm get values` commands etc.

- **Add support for LoadBalancer service**
- **Tidy up secrets**
- **Fix ingress ports**
