### PR TITLE
feat: Add operator helm chart

### DIFF
--- a/charts/operator/.helmignore
+++ b/charts/operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -1,7 +1,13 @@
 apiVersion: v2
 name: operator
 description: A Helm chart for the operator that manages syncs on the CloudQuery platform
-
+icon: https://avatars.githubusercontent.com/u/74616112
+keywords: [cloudquery]
+sources:
+  - https://github.com/cloudquery/helm-charts/tree/main/charts/operator
+maintainers:
+  - name: yevgenypats
+    email: yp@cloudquery.io
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives
@@ -22,3 +28,12 @@ version: 0.1.0
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "v0.50.0"
+
+annotations:
+  artifacthub.io/license: MPL-2.0
+  artifacthub.io/links: |
+    - name: cloudquery
+      url: https://github.com/cloudquery/cloudquery
+  artifacthub.io/maintainers: |
+    - name: yevgenypats
+      email: yp@cloudquery.io

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: operator
+description: A Helm chart for the operator that manages syncs on the CloudQuery platform
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v0.50.0"

--- a/charts/operator/README.md
+++ b/charts/operator/README.md
@@ -1,0 +1,86 @@
+# operator
+
+A Helm chart for the operator that manages syncs on the CloudQuery platform
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.50.0](https://img.shields.io/badge/AppVersion-v0.50.0-informational?style=flat-square)
+
+## Quickstart
+
+The operator is a platform component that schedules syncs on a Kubernetes cluster.
+
+### Default Configuration
+
+The chart doesn't require any configuration parameters, so the easiest way to get started is by running the following commands:
+
+```console
+helm repo add cloudquery https://cloudquery.github.io/helm-charts/
+helm upgrade scheduler --atomic --install -n cloudquery cloudquery/operator
+```
+
+This command ensures the operator is installed or updated to the latest version.
+If something goes wrong during the deployment, it will automatically roll back any changes made to the cluster.
+
+> [!IMPORTANT]
+> While the operator can be deployed either before or after the platform, it's essential to deploy the operator before setting up integrations or running syncs.
+> The operator must be connected to the platform for these actions to work.
+
+Upon successful deployment, the command will output a message with configuration details to connect the platform installation to the scheduler.
+
+If you're using the default configuration for both the platform and the operator, the platform pods will automatically connect to the scheduler, and you can safely ignore the message.
+
+### Non-default configurations
+
+However, if you're using a non-default configuration (e.g., you've deployed the components to different namespaces or changed the helm release name),
+you'll need to use the config from a success message provided by helm to ensure the platform is connected to the scheduler.
+
+The message will include a configuration snippet like the one below:
+
+```yaml
+# Add the following snippet to your Helm configuration YAML during platform installation or upgrade
+# to ensure the platform can communicate with the operator:
+scheduler:
+  address: scheduler-operator.cloudquery:3001
+```
+
+Create a file named `scheduler.yaml` and paste the snippet into it.
+Then, to install or update the platform using this configuration, supply the file to the Helm command as follows:
+
+```console
+helm upgrade --install --atomic platform -n cloudquery --create-namespace cloudquery/platform --values <platform-configs> --values ./scheduler.yaml
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Configures node affinity for the operator deployment  See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity. |
+| environment | object | `{"SCHEDULER_K8S_LEADER_ELECTION_NAMESPACE":"","SCHEDULER_K8S_SYNC_NAMESPACE":""}` | Configures environment variables for the operator Deployment |
+| environment.SCHEDULER_K8S_LEADER_ELECTION_NAMESPACE | string | `""` | The namespace to use for leader election. If not provided, will be the release namespace. |
+| environment.SCHEDULER_K8S_SYNC_NAMESPACE | string | `""` | The namespace to use to spawn syncs. If not provided, will be the release namespace. |
+| fullnameOverride | string | `""` | Override the full name |
+| image | object | `{"pullPolicy":"IfNotPresent","pullSecrets":[],"repository":"us-east1-docker.pkg.dev/cq-cloud-prod/platform/scheduler","tag":""}` | Configures the container image for the operator Deployment. See https://kubernetes.io/docs/concepts/containers/images/. |
+| image.pullPolicy | string | `"IfNotPresent"` | IfNotPresent, Always, Never |
+| image.pullSecrets | list | `[]` | This sets secrets for repositories that require auth. See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/. |
+| image.repository | string | `"us-east1-docker.pkg.dev/cq-cloud-prod/platform/scheduler"` | Configures repository and registry to use when pulling a scheduler image |
+| image.tag | string | `""` | Image tag to use. If empty, will use the chart's 'appVersion' |
+| livenessProbe | object | `{"initialDelaySeconds":15,"periodSeconds":10,"tcpSocket":{"port":"grpc"}}` | Configures the probes for the operator deployment. See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/. |
+| nameOverride | string | `""` | Override the default name |
+| nodeSelector | object | `{}` | Configures node selectors for the operator deployment  See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector. |
+| podAnnotations | object | `{}` | Configures additional labels on the operator Deployment. See https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/. |
+| podLabels | object | `{}` | Configures additional labels on the operator Deployment. See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/. |
+| readinessProbe.initialDelaySeconds | int | `15` |  |
+| readinessProbe.periodSeconds | int | `10` |  |
+| readinessProbe.tcpSocket.port | string | `"grpc"` |  |
+| replicaCount | int | `1` | Configures the replica count for the deployment. For out-of-cluster deployments in the dev environment, set this to zero and ignore all the sections related to the Deployment. See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/. |
+| resources | object | `{"limits":{"cpu":"500m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Configures resource profile for the operator deployment. See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/. |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` | Configures the security context of the operator Deployment. See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/. |
+| service | object | `{"annotations":{},"enabled":true,"port":3001,"targetPort":"grpc","type":"ClusterIP"}` | Create a Kubernetes Service that allows gRPC connectivity to the Operator API. Needed for the CloudQuery platform deployments since the platform will use this to communicate with the scheduler. See https://kubernetes.io/docs/concepts/services-networking/service/. |
+| serviceAccount | object | `{"annotations":{},"automount":true,"create":true,"name":""}` | This section builds out the service account. See https://kubernetes.io/docs/concepts/security/service-accounts/. |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.automount | bool | `true` | Automatically mount a service account's token in the operator pod |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| tolerations | list | `[]` | Configures node tolerations for the operator deployment  See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/. |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)

--- a/charts/operator/README.md.gotmpl
+++ b/charts/operator/README.md.gotmpl
@@ -1,0 +1,55 @@
+{{ template "chart.header" . }}
+{{ template "chart.description" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+## Quickstart
+
+The operator is a platform component that schedules syncs on a Kubernetes cluster.
+
+### Default Configuration
+
+The chart doesn't require any configuration parameters, so the easiest way to get started is by running the following commands:
+
+```console
+helm repo add cloudquery https://cloudquery.github.io/helm-charts/
+helm upgrade scheduler --atomic --install -n cloudquery cloudquery/operator
+```
+
+This command ensures the operator is installed or updated to the latest version.
+If something goes wrong during the deployment, it will automatically roll back any changes made to the cluster.
+
+> [!IMPORTANT]
+> While the operator can be deployed either before or after the platform, it's essential to deploy the operator before setting up integrations or running syncs.
+> The operator must be connected to the platform for these actions to work.
+
+Upon successful deployment, the command will output a message with configuration details to connect the platform installation to the scheduler.
+
+If you're using the default configuration for both the platform and the operator, the platform pods will automatically connect to the scheduler, and you can safely ignore the message.
+
+### Non-default configurations
+
+However, if you're using a non-default configuration (e.g., you've deployed the components to different namespaces or changed the helm release name), 
+you'll need to use the config from a success message provided by helm to ensure the platform is connected to the scheduler.
+
+The message will include a configuration snippet like the one below:
+
+```yaml
+# Add the following snippet to your Helm configuration YAML during platform installation or upgrade
+# to ensure the platform can communicate with the operator:
+scheduler:
+  address: scheduler-operator.cloudquery:3001
+```
+
+Create a file named `scheduler.yaml` and paste the snippet into it.
+Then, to install or update the platform using this configuration, supply the file to the Helm command as follows:
+
+```console
+helm upgrade --install --atomic platform -n cloudquery --create-namespace cloudquery/platform --values <platform-configs> --values ./scheduler.yaml
+```
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/operator/crds/scheduling.cloudquery.io_connectiontests.yaml
+++ b/charts/operator/crds/scheduling.cloudquery.io_connectiontests.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: connectiontests.scheduling.cloudquery.io
+spec:
+  group: scheduling.cloudquery.io
+  names:
+    categories:
+    - cloudquery
+    - cq
+    kind: ConnectionTest
+    listKind: ConnectionTestList
+    plural: connectiontests
+    shortNames:
+    - ct
+    - conntest
+    singular: connectiontest
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    - jsonPath: .status.error
+      name: Error
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              configName:
+                description: |-
+                  ConfigName is the name of the ConfigMap that stores the CloudQuery configuration to use for the sync job.
+                  If not specified, this defaults to the name of the Sync object in the same namespace.
+                  This should at a minimum contain the `config.yaml` configuration file, but can include
+                  non-secret environment variables as well.
+                type: string
+              image:
+                description: Image is an optional container image of the CloudQuery
+                  launcher to use for the sync job.
+                type: string
+              secretName:
+                description: |-
+                  SecretName is the name of the Secret that stores the secret environment variables to use for the sync job.
+                  If not specified, this defaults to the name of the Sync object in the same namespace.
+                  At a minimum, this should contain the `CLOUDQUERY_API_KEY` secret environment variable but any other configured
+                  one will be added to the sync environment as long as it follows the naming pattern requested by the CLI.
+                  eg. `__SOURCE_{SOURCE_NAME}__{ENVIRONMENT_VARIABLE_NAME}`, `__DESTINATION_{DESTINATION_NAME}__{ENVIRONMENT_VARIABLE_NAME}`
+                type: string
+            type: object
+          status:
+            description: ConnectionTestStatus defines the observed state of Sync
+            properties:
+              error:
+                type: string
+              status:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/operator/crds/scheduling.cloudquery.io_syncs.yaml
+++ b/charts/operator/crds/scheduling.cloudquery.io_syncs.yaml
@@ -1,0 +1,149 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: syncs.scheduling.cloudquery.io
+spec:
+  group: scheduling.cloudquery.io
+  names:
+    categories:
+    - cloudquery
+    - cq
+    kind: Sync
+    listKind: SyncList
+    plural: syncs
+    singular: sync
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              configName:
+                description: |-
+                  ConfigName is the name of the ConfigMap that stores the CloudQuery configuration to use for the sync job.
+                  If not specified, this defaults to the name of the Sync object in the same namespace.
+                  This should at a minimum contain the `config.yaml` configuration file, but can include
+                  non-secret environment variables as well.
+                type: string
+              image:
+                description: Image is an optional container image of the CloudQuery
+                  launcher to use for the sync job.
+                type: string
+              resources:
+                description: |-
+                  Resources is an optional field to specify the resource requirements for the sync jobs.
+                  These apply to every shard of a sync job.
+                properties:
+                  claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
+
+                      This is an alpha field and requires enabling the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable. It can only be set for containers.
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used. It makes that resource available
+                            inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Requests describes the minimum amount of compute resources required.
+                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
+              secretName:
+                description: |-
+                  SecretName is the name of the Secret that stores the secret environment variables to use for the sync job.
+                  If not specified, this defaults to the name of the Sync object in the same namespace.
+                  At a minimum, this should contain the `CLOUDQUERY_API_KEY` secret environment variable but any other configured
+                  one will be added to the sync environment as long as it follows the naming pattern requested by the CLI.
+                  eg. `__SOURCE_{SOURCE_NAME}__{ENVIRONMENT_VARIABLE_NAME}`, `__DESTINATION_{DESTINATION_NAME}__{ENVIRONMENT_VARIABLE_NAME}`
+                type: string
+              shards:
+                description: |-
+                  Shards is an optional field to specify the number of shards to use for the sync job.
+                  This defaults to 1 if not specified, meaning the sync process will not be sharded.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: Status defines the observed state of Sync
+            properties:
+              error:
+                type: string
+              exitCode:
+                format: int32
+                type: integer
+              status:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/operator/templates/NOTES.txt
+++ b/charts/operator/templates/NOTES.txt
@@ -1,0 +1,18 @@
+{{ .Chart.Name | title }} release `{{ .Release.Name }}/{{ .Release.Revision }}` has been installed!
+
+    .--.
+ .-(    ).    Happy CloudQuery-ing!
+(___.__)__)
+
+---
+
+# Add the following snippet to your Helm configuration YAML during platform installation or upgrade
+# to ensure the platform can communicate with the operator:
+scheduler:
+  address: {{ include "operator.fullname" . }}.{{ .Release.Namespace }}:3001
+
+---
+
+Alternatively, you can append the --set flag to your Helm command:
+
+  helm install <params> --set "scheduler.address={{ include "operator.fullname" . }}.{{ .Release.Namespace }}:3001"

--- a/charts/operator/templates/_helpers.tpl
+++ b/charts/operator/templates/_helpers.tpl
@@ -1,0 +1,70 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "operator.labels" -}}
+helm.sh/chart: {{ include "operator.chart" . }}
+{{ include "operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "operator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Specifies default environment variables for the scheduler
+*/}}
+{{- define "operator.defaultEnv" -}}
+SCHEDULER_K8S_LEADER_ELECTION_NAMESPACE: {{ .Release.Namespace }}
+SCHEDULER_K8S_SYNC_NAMESPACE: {{ .Release.Namespace }}
+{{- end}}

--- a/charts/operator/templates/deployment.yaml
+++ b/charts/operator/templates/deployment.yaml
@@ -1,0 +1,74 @@
+{{ if gt (int .Values.replicaCount) 0 -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "operator.fullname" . }}
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "operator.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "operator.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      securityContext: {}
+      containers:
+        - name: {{ .Chart.Name }}
+          args: [kubernetes]
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "%s-k8s" .Chart.AppVersion ) }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - containerPort: 3001
+              name: grpc
+          env:
+          {{- $mergedEnv := merge  (.Values.environment | default dict ) (include "operator.defaultEnv" . | fromYaml ) }}
+          {{- range $key, $val := $mergedEnv }}
+            - name: {{ $key }}
+              value: {{ $val }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/operator/templates/role-api.yaml
+++ b/charts/operator/templates/role-api.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-api-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - scheduling.cloudquery.io
+  resources:
+  - connectiontests
+  - syncs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scheduling.cloudquery.io
+  resources:
+  - connectiontests/status
+  - syncs/status
+  verbs:
+  - get

--- a/charts/operator/templates/role-bindings.yaml
+++ b/charts/operator/templates/role-bindings.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-manager-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-manager-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-api-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-api-role
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/operator/templates/role-manager.yaml
+++ b/charts/operator/templates/role-manager.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - pods/log
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+- apiGroups:
+  - scheduling.cloudquery.io
+  resources:
+  - connectiontests
+  - syncs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scheduling.cloudquery.io
+  resources:
+  - connectiontests/finalizers
+  - syncs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - scheduling.cloudquery.io
+  resources:
+  - connectiontests/status
+  - syncs/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/charts/operator/templates/service.yaml
+++ b/charts/operator/templates/service.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "operator.fullname" . }}
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: {{ .Values.service.targetPort }}
+    protocol: TCP
+    name: grpc
+  selector:
+    {{- include "operator.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/operator/templates/serviceaccount.yaml
+++ b/charts/operator/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "operator.serviceAccountName" . }}
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -1,0 +1,106 @@
+# -- Override the default name
+nameOverride: ""
+# -- Override the full name
+fullnameOverride: ""
+
+# -- Configures the replica count for the deployment.
+# For out-of-cluster deployments in the dev environment, set this to zero and ignore all the sections related to the Deployment.
+# See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/.
+replicaCount: 1
+
+# -- Configures the container image for the operator Deployment.
+# See https://kubernetes.io/docs/concepts/containers/images/.
+image:
+  # -- Configures repository and registry to use when pulling a scheduler image
+  repository: us-east1-docker.pkg.dev/cq-cloud-prod/platform/scheduler
+  # -- Image tag to use. If empty, will use the chart's 'appVersion'
+  tag: ""
+  # -- IfNotPresent, Always, Never
+  pullPolicy: IfNotPresent
+  # -- This sets secrets for repositories that require auth.
+  # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/.
+  pullSecrets: []
+
+# -- Configures environment variables for the operator Deployment
+environment:
+  # -- The namespace to use for leader election. If not provided, will be the release namespace.
+  SCHEDULER_K8S_LEADER_ELECTION_NAMESPACE: ""
+  # -- The namespace to use to spawn syncs. If not provided, will be the release namespace.
+  SCHEDULER_K8S_SYNC_NAMESPACE: ""
+
+# -- This section builds out the service account.
+# See https://kubernetes.io/docs/concepts/security/service-accounts/.
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Automatically mount a service account's token in the operator pod
+  automount: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# -- Configures additional labels on the operator Deployment.
+# See https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/.
+podAnnotations: {}
+
+# -- Configures additional labels on the operator Deployment.
+# See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/.
+podLabels: {}
+
+# -- Configures the security context of the operator Deployment.
+# See https://kubernetes.io/docs/tasks/configure-pod-container/security-context/.
+securityContext:
+  capabilities:
+    drop: [ALL]
+
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+
+  runAsGroup: 1000
+  runAsUser: 1000
+  runAsNonRoot: true
+
+# -- Configures resource profile for the operator deployment.
+# See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/.
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+# -- Create a Kubernetes Service that allows gRPC connectivity to the Operator API.
+# Needed for the CloudQuery platform deployments since the platform will use this to communicate with the scheduler.
+# See https://kubernetes.io/docs/concepts/services-networking/service/.
+service:
+  enabled: true
+  type: ClusterIP
+  port: 3001
+  targetPort: grpc
+  annotations: {}
+
+# -- Configures the probes for the operator deployment.
+# See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/.
+livenessProbe:
+  tcpSocket:
+    port: grpc
+  initialDelaySeconds: 15
+  periodSeconds: 10
+readinessProbe:
+  tcpSocket:
+    port: grpc
+  initialDelaySeconds: 15
+  periodSeconds: 10
+
+# -- Configures node selectors for the operator deployment
+# See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.
+nodeSelector: {}
+# -- Configures node affinity for the operator deployment
+# See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity.
+affinity: {}
+# -- Configures node tolerations for the operator deployment
+# See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/.
+tolerations: []

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -231,7 +231,7 @@ Kubernetes: `^1.8.0-0`
 | readinessProbe.periodSeconds | int | `30` |  |
 | replicaCount | int | `1` | The number of replicas to deploy |
 | resources | object | `{}` | Deployment resources |
-| scheduler | object | `{"address":"scheduler-cloudquery-operator:3001"}` | Specify the scheduler configuration |
+| scheduler | object | `{"address":"scheduler-operator:3001"}` | Specify the scheduler configuration |
 | service | object | `{"apiPort":4444,"apiType":"ClusterIP","proxyPort":3000,"proxyType":"ClusterIP","storagePort":4445,"storageType":"ClusterIP","uiPort":3001,"uiType":"ClusterIP"}` | Specify the ports the container exposes |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.automount | bool | `true` |  |

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -44,7 +44,7 @@ service:
 
 # -- Specify the scheduler configuration
 scheduler:
-  address: scheduler-cloudquery-operator:3001
+  address: scheduler-operator:3001
 
 # -- Deployment resources
 resources:


### PR DESCRIPTION
This PR introduces a Helm chart that deploys a platform scheduler as a Kubernetes operator.

By default, the scheduler is automatically detected by the platform and serves as its scheduling backend. For custom configurations, the chart provides the necessary configuration section as output.

```
Operator release `scheduler/2` has been installed!

    .--.
 .-(    ).    Happy CloudQuery-ing!
(___.__)__)

---

# Add the following snippet to your Helm configuration YAML during platform installation or upgrade
# to ensure the platform can communicate with the operator:
scheduler:
  address: scheduler-operator.cloudquery:3001

---

Alternatively, you can append the --set flag to your Helm command:

  helm install <params> --set "scheduler.address=scheduler-operator.cloudquery:3001"
```