### PR TITLE
feat: Adding persistent volume

### DIFF
--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -216,22 +216,27 @@ Kubernetes: `^1.8.0-0`
 | livenessProbe.httpGet.port | string | `"api"` |  |
 | livenessProbe.periodSeconds | int | `60` |  |
 | nameOverride | string | `""` | Override the default name |
-| otelCollector | object | `{"containerSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},"readOnlyRootFilesystem":true},"database":"default","enabled":true,"image":{"pullPolicy":"IfNotPresent","repository":"otel/opentelemetry-collector-contrib","tag":"0.118.0"},"podSecurityContext":{"readOnlyRootFilesystem":true,"runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10001,"seccompProfile":{"type":"RuntimeDefault"}},"resources":{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"500m","memory":"512Mi"}},"service":{"ports":[{"name":"otlp-grpc","port":4317,"protocol":"TCP","targetPort":4317},{"name":"otlp-http","port":4318,"protocol":"TCP","targetPort":4318}],"type":"ClusterIP"}}` | OTEL Collector configuration |
+| otelCollector | object | `{"containerSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},"readOnlyRootFilesystem":true},"database":"default","enabled":true,"image":{"pullPolicy":"IfNotPresent","repository":"otel/opentelemetry-collector-contrib","tag":"0.118.0"},"podSecurityContext":{"runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10001,"seccompProfile":{"type":"RuntimeDefault"}},"resources":{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"500m","memory":"512Mi"}},"service":{"ports":[{"name":"otlp-grpc","port":4317,"protocol":"TCP","targetPort":4317},{"name":"otlp-http","port":4318,"protocol":"TCP","targetPort":4318}],"type":"ClusterIP"}}` | OTEL Collector configuration |
 | otelCollector.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},"readOnlyRootFilesystem":true}` | Specify the container-level security context |
 | otelCollector.database | string | `"default"` | Optional. The database to use for the ClickHouse exporter (should match the ClickHouse DSN) |
 | otelCollector.enabled | bool | `true` | Optional. Enable the OTEL Collector. |
-| otelCollector.podSecurityContext | object | `{"readOnlyRootFilesystem":true,"runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10001,"seccompProfile":{"type":"RuntimeDefault"}}` | Specify the pod-level security context |
+| otelCollector.podSecurityContext | object | `{"runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10001,"seccompProfile":{"type":"RuntimeDefault"}}` | Specify the pod-level security context |
+| persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
+| persistence.annotations | object | `{}` |  |
+| persistence.enabled | bool | `false` |  |
+| persistence.size | string | `"100Gi"` |  |
+| persistence.type | string | `"gp2"` |  |
 | platformSecrets | object | `{"jwtPrivateKeyRef":"","secretRef":"cq-platform-secrets"}` | Platform secrets configuration |
 | platformSecrets.jwtPrivateKeyRef | string | `""` | JWT private key reference for the self-hosted platform - if not provided, a new key will be generated |
 | platformSecrets.secretRef | string | `"cq-platform-secrets"` | Required: The secret reference to use for the user-supplied platform secrets |
 | podAnnotations | object | `{}` | Addition pod annotations |
 | podLabels | object | `{}` | Addition pod labels |
-| podSecurityContext | object | `{"fsGroup":3001,"readOnlyRootFilesystem":true,"runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10001,"seccompProfile":{"type":"RuntimeDefault"}}` | Specify the pod-level security context |
+| podSecurityContext | object | `{"fsGroup":3001,"runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10001,"seccompProfile":{"type":"RuntimeDefault"}}` | Specify the pod-level security context |
 | readinessProbe.httpGet.path | string | `"/"` |  |
 | readinessProbe.httpGet.port | string | `"api"` |  |
 | readinessProbe.periodSeconds | int | `30` |  |
 | replicaCount | int | `1` | The number of replicas to deploy |
-| resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"500m","memory":"512Mi"}}` | Deployment resources |
+| resources | object | `{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"500m","memory":"512Mi"}}` | Deployment resources |
 | scheduler | object | `{"address":"scheduler-operator:3001"}` | Specify the scheduler configuration |
 | service | object | `{"annotations":{},"port":3000,"targetPort":3000,"type":"ClusterIP"}` | Specify the ports the container exposes |
 | serviceAccount.annotations | object | `{}` |  |
@@ -239,8 +244,8 @@ Kubernetes: `^1.8.0-0`
 | serviceAccount.create | bool | `false` |  |
 | serviceAccount.name | string | `""` |  |
 | testingSecret | object | `{"activationKey":"","clickhouseDSN":"","enabled":false,"postgresqlDSN":""}` | Testing secret configuration - only used during CI/CD |
-| volumeMounts | list | `[{"mountPath":"/shared","name":"shared"},{"mountPath":"/var/log","name":"logs"},{"mountPath":"/tmp","name":"tmp"},{"mountPath":"/data/storage","name":"storage"}]` | Additional volumeMounts on the output Deployment definition. |
-| volumes | list | `[{"emptyDir":{},"name":"shared"},{"emptyDir":{},"name":"logs"},{"emptyDir":{},"name":"tmp"},{"emptyDir":{},"name":"storage"}]` | Additional volumes on the output Deployment definition. |
+| volumeMounts | list | `[{"mountPath":"/shared","name":"shared"},{"mountPath":"/var/log","name":"logs"},{"mountPath":"/tmp","name":"tmp"}]` | Additional volumeMounts on the output Deployment definition. |
+| volumes | list | `[{"emptyDir":{},"name":"shared"},{"emptyDir":{},"name":"logs"},{"emptyDir":{},"name":"tmp"}]` | Additional volumes on the output Deployment definition. |
 
 ----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)

--- a/charts/platform/templates/deployments.yaml
+++ b/charts/platform/templates/deployments.yaml
@@ -54,7 +54,7 @@ spec:
                   name: {{ include "platform.secretRef" . }}
                   key: clickhouseDSN
             - name: CQAPI_LOCAL_AES_KEY_FILE
-              value: "/shared/encrypted_aes_key.bin"
+              value: "/data/storage/encrypted_aes_key.bin"
             - name: CQAPI_LOCAL_JWT_PRIVATE_KEY
               valueFrom:
                 secretKeyRef:
@@ -95,6 +95,8 @@ spec:
             - name: nginx-config
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
+            - name: storage
+              mountPath: /data/storage
       volumes:
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
@@ -102,6 +104,13 @@ spec:
         - name: nginx-config
           configMap:
             name: {{ include "platform.fullName" . }}-nginx-conf
+        - name: storage
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "platform.fullName" . }}-pvc
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/platform/templates/pvc.yaml
+++ b/charts/platform/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "platform.fullName" . }}-pvc
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- range .Values.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  storageClassName: {{ include "platform.fullName" . }}-sc
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/platform/templates/storageclass.yaml
+++ b/charts/platform/templates/storageclass.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ include "platform.fullName" . }}-sc
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: ebs.csi.eks.amazonaws.com
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  type: {{ .Values.persistence.type }}
+  encrypted: "true"
+{{- end }}

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -27,7 +27,6 @@ podLabels: {}
 
 # -- Specify the pod-level security context
 podSecurityContext:
-  readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 10001
   runAsGroup: 10001
@@ -56,12 +55,12 @@ scheduler:
 
 # -- Deployment resources
 resources:
-  limits:
-    cpu: 500m
-    memory: 512Mi
   requests:
     cpu: 500m
     memory: 512Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
 
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
@@ -75,27 +74,27 @@ readinessProbe:
     path: /
     port: api
 
+persistence:
+  enabled: false
+  type: "gp2" # AWS EBS storage class
+  accessModes:
+    - ReadWriteOnce
+  size: 100Gi
+  annotations: {}
+
 # -- Additional volumes on the output Deployment definition.
 volumes:
-  - name: shared
-    emptyDir: {}
   - name: logs
     emptyDir: {}
   - name: tmp
-    emptyDir: {}
-  - name: storage
     emptyDir: {}
 
 # -- Additional volumeMounts on the output Deployment definition.
 volumeMounts:
-  - name: shared
-    mountPath: /shared
   - name: logs
     mountPath: /var/log
   - name: tmp
     mountPath: /tmp
-  - name: storage
-    mountPath: /data/storage
 
 # -- Platform secrets configuration
 platformSecrets:
@@ -156,7 +155,6 @@ otelCollector:
 
   # -- Specify the pod-level security context
   podSecurityContext:
-    readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 10001
     runAsGroup: 10001

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -76,7 +76,7 @@ readinessProbe:
 
 persistence:
   enabled: false
-  type: "gp2" # AWS EBS storage class
+  type: "gp2"
   accessModes:
     - ReadWriteOnce
   size: 100Gi


### PR DESCRIPTION
Adding a persistent volume to allow the mirrored plugins to be stored.

- In addition, store the `CQAPI_LOCAL_AES_KEY_FILE` in the persistent volume
- Removed `readOnlyRootFilesystem` value from the pod-level spec (only needs to be in the container)
