### PR TITLE
fix: Prepend `v` to the image tag

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
     email: yp@cloudquery.io
 type: application
 version: 0.2.0
-appVersion: v0.50.0
+appVersion: 0.50.0
 annotations:
   artifacthub.io/license: MPL-2.0
   artifacthub.io/links: |

--- a/charts/operator/templates/deployment.yaml
+++ b/charts/operator/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           args: [kubernetes]
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "%s-k8s" .Chart.AppVersion ) }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s-k8s" .Chart.AppVersion ) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}


### PR DESCRIPTION
This makes the version update compatible with the renovate regex already used in the platform chart: see https://github.com/cloudquery/helm-charts/pull/599
