### PR TITLE
feat: Add init container to check and create database if missing

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -15,9 +15,10 @@ jobs:
         env:
           POSTGRES_PASSWORD: pass
       clickhouse:
-        image:  clickhouse/clickhouse-server
+        image: clickhouse/clickhouse-server
         ports:
           - 9000:9000
+          - 8123:8123
         env:
           CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: "1"
           CLICKHOUSE_DB: assets

--- a/charts/platform/templates/_helpers.tpl
+++ b/charts/platform/templates/_helpers.tpl
@@ -89,3 +89,20 @@ Get the appropriate secret reference name based on whether external secrets is e
 {{- include "platform.fullName" . }}-jwt-private-key
 {{- end -}}
 {{- end -}}
+
+{{/*
+Init containers definition
+*/}}
+{{- define "platform.initContainers" -}}
+- name: init-clickhouse
+  image: curlimages/curl:8.5.0
+  command:
+    - /bin/sh
+    - /scripts/init-clickhouse.sh
+  volumeMounts:
+    - name: init-scripts
+      mountPath: /scripts
+    - name: platform-secrets
+      mountPath: /secrets
+      readOnly: true
+{{- end -}}

--- a/charts/platform/templates/configmap.tpl
+++ b/charts/platform/templates/configmap.tpl
@@ -28,3 +28,44 @@ data:
   collector.yaml: |-
     {{ .Files.Get "config/otel-config.yaml" | nindent 4 }}
 {{- end }}
+---
+{{- define "platform.clickhouse-init-script" -}}
+#!/bin/bash
+set -e
+
+# Parse Clickhouse DSN
+parse_clickhouse_dsn() {
+    local dsn="$1"
+    # Extract components from clickhouse://user:pass@host:port/db
+    export CH_USER=$(echo "$dsn" | sed -n 's|clickhouse://\([^:]*\):.*|\1|p')
+    export CH_PASS=$(echo "$dsn" | sed -n 's|clickhouse://[^:]*:\([^@]*\)@.*|\1|p')
+    export CH_HOST=$(echo "$dsn" | sed -n 's|.*@\([^:]*\):.*|\1|p')
+    export CH_PORT=$(echo "$dsn" | sed -n 's|.*:\([^/]*\)/.*|\1|p')
+    export CH_DB=$(echo "$dsn" | sed -n 's|.*/\(.*\)|\1|p')
+}
+
+# Get Clickhouse DSN from secret
+CLICKHOUSE_DSN=$(cat /secrets/clickhouseDSN)
+parse_clickhouse_dsn "$CLICKHOUSE_DSN"
+
+# Create database if it doesn't exist
+check_db="SELECT name FROM system.databases WHERE name = '$CH_DB'"
+create_db="CREATE DATABASE IF NOT EXISTS $CH_DB"
+
+if ! echo "$check_db" | curl "https://$CH_HOST:8443/" --silent -u "$CH_USER:$CH_PASS" --data-binary @- | grep -q "$CH_DB"; then
+    echo "Creating database $CH_DB..."
+    echo "$create_db" | curl "https://$CH_HOST:8443/" --silent -u "$CH_USER:$CH_PASS" --data-binary @-
+    echo "Database $CH_DB created successfully"
+else
+    echo "Database $CH_DB already exists"
+fi
+{{- end -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "platform.fullName" . }}-init-scripts
+  namespace: {{ .Release.Namespace }}
+data:
+  init-clickhouse.sh: |-
+{{ include "platform.clickhouse-init-script" . | indent 4 }}

--- a/charts/platform/templates/configmap.tpl
+++ b/charts/platform/templates/configmap.tpl
@@ -40,8 +40,8 @@ parse_clickhouse_dsn() {
     export CH_USER=$(echo "$dsn" | sed -n 's|clickhouse://\([^:]*\):.*|\1|p')
     export CH_PASS=$(echo "$dsn" | sed -n 's|clickhouse://[^:]*:\([^@]*\)@.*|\1|p')
     export CH_HOST=$(echo "$dsn" | sed -n 's|.*@\([^:]*\):.*|\1|p')
-    export CH_PORT=$(echo "$dsn" | sed -n 's|.*:\([^/]*\)/.*|\1|p')
-    export CH_DB=$(echo "$dsn" | sed -n 's|.*/\(.*\)|\1|p')
+    export CH_PORT=$(echo "$dsn" | sed -n 's|.*:\([^/?]*\)/.*|\1|p')
+    export CH_DB=$(echo "$dsn" | sed -n 's|.*/\([^?]*\).*|\1|p') 
 }
 
 # Get Clickhouse DSN from secret

--- a/charts/platform/templates/deployments.yaml
+++ b/charts/platform/templates/deployments.yaml
@@ -1,4 +1,3 @@
-# deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/platform/templates/deployments.yaml
+++ b/charts/platform/templates/deployments.yaml
@@ -1,3 +1,4 @@
+# deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -31,6 +32,8 @@ spec:
       serviceAccountName: {{ include "platform.serviceAccount" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+{{ include "platform.initContainers" . | indent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -97,6 +100,13 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        - name: init-scripts
+          configMap:
+            name: {{ include "platform.fullName" . }}-init-scripts
+            defaultMode: 0755
+        - name: platform-secrets
+          secret:
+            secretName: {{ include "platform.fullName" . }}-external-secrets
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/platform/templates/deployments.yaml
+++ b/charts/platform/templates/deployments.yaml
@@ -105,7 +105,7 @@ spec:
             defaultMode: 0755
         - name: platform-secrets
           secret:
-            secretName: {{ include "platform.fullName" . }}-external-secrets
+            secretName: {{ include "platform.secretRef" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Add Clickhouse database initialization via init container

This PR adds a database initialization step for Clickhouse using an init container that:
- Parses the Clickhouse DSN from external secrets
- Checks if the target database exists
- Creates the database if it doesn't exist
- Uses curlimages/curl:8.5.0 for minimal footprint 
