### PR TITLE
feat: Adding pod disruption budget

### DIFF
--- a/charts/platform/templates/pdb.yaml
+++ b/charts/platform/templates/pdb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "platform.fullName" . }}
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "platform.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: application
+{{- end }}

--- a/charts/platform/templates/pdb.yaml
+++ b/charts/platform/templates/pdb.yaml
@@ -17,3 +17,24 @@ spec:
       {{- include "platform.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: application
 {{- end }}
+---
+{{- if .Values.otelCollector.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "platform.fullName" . }}-otel-collector
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+spec:
+  {{- with .Values.otelCollector.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.otelCollector.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "platform.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: otel-collector
+{{- end }}

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -25,6 +25,9 @@ podAnnotations: {}
 # -- Addition pod labels
 podLabels: {}
 
+podDisruptionBudget:
+  minAvailable: 1
+
 # -- Specify the pod-level security context
 podSecurityContext:
   runAsNonRoot: true

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -132,6 +132,9 @@ otelCollector:
   # -- Optional. The database to use for the ClickHouse exporter (should match the ClickHouse DSN)
   database: "default"
 
+  podDisruptionBudget:
+    minAvailable: 1
+
   resources:
     requests:
       cpu: 500m


### PR DESCRIPTION
The EKS cluster we are using is configured as an EKS auto cluster. This results in nodes being auto-provisioned whenever pods exceed the available resources. This happens when a sync is triggered, which can lead to the platform and otel-collector pods being re-scheduled onto the new node.

This PR adds Pod Disruption Budgets to ensure that both the platform and otel-collector pods are not interrupted when node scaling occurs. This will likely result in the original node being protected form eviction whilst the sync jobs will be scheduled on a new, bigger node.

![image](https://github.com/user-attachments/assets/2a88abd6-be18-4c05-b95c-247cd92e98d4)

