### PR TITLE
fix: Remove AES key file

### DIFF
--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
   - name: yevgenypats
     email: yp@cloudquery.io
 version: 0.11.1
-appVersion: 0.65.0
+appVersion: 0.67.0
 annotations:
   artifacthub.io/license: MPL-2.0
   artifacthub.io/links: |

--- a/charts/platform/templates/configmap.tpl
+++ b/charts/platform/templates/configmap.tpl
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "platform.labels" . | nindent 4 }}
 data:
-  CQAPI_LOCAL_AES_KEY_FILE: "/data/storage/encrypted_aes_key.bin"
   CQAPI_LOCAL_COOKIE_SECURE: "false"
   CQAPI_MIRROR_ENABLED: "true"
   CQAPI_MIRROR_ALL_PLUGINS: "false"


### PR DESCRIPTION
This will effectively enable key storage and retrieval via Postgres, preventing key re-generation if the platform pod start in a different zone.

Refs: cloudquery/cloud#4207
