### PR TITLE
fix: Mirror all plugins by default

### DIFF
--- a/charts/platform/templates/configmap.tpl
+++ b/charts/platform/templates/configmap.tpl
@@ -7,7 +7,7 @@ metadata:
 data:
   CQAPI_LOCAL_COOKIE_SECURE: "false"
   CQAPI_MIRROR_ENABLED: "true"
-  CQAPI_MIRROR_ALL_PLUGINS: "false"
+  CQAPI_MIRROR_ALL_PLUGINS: "true"
   CQAPI_ASSETVIEW_INTERVAL: "1m"
   CQAPI_STORAGE_LOCAL_RELEASE_BASE_URL: "http://{{ include "platform.fullName" . }}.{{ .Release.Namespace }}:{{ .Values.service.targetPort }}/storage/files"
   CQAPI_STORAGE_LOCAL_UIASSET_BASE_URL: "/storage/files"


### PR DESCRIPTION
This is temporary until some further frontend work enables lazy loading for plugins.