### PR TITLE
fix: Allow platform container to read logs from k8s API

### DIFF
--- a/charts/platform/templates/role.yaml
+++ b/charts/platform/templates/role.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "platform.fullName" . }}-log-reader
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch"]

--- a/charts/platform/templates/rolebinding.yaml
+++ b/charts/platform/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "platform.fullName" . }}-log-reader
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "platform.serviceAccount" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "platform.fullName" . }}-log-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/platform/templates/serviceaccount.yaml
+++ b/charts/platform/templates/serviceaccount.yaml
@@ -1,3 +1,17 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "platform.serviceAccount" . }}
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}
+---
 {{- if index .Values "externalSecrets" "enabled" -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -14,7 +14,7 @@ nameOverride: ""
 fullNameOverride: ""
 
 serviceAccount:
-  create: false
+  create: true
   automount: true
   annotations: {}
   name: ""


### PR DESCRIPTION
I think the lack of RBAC rules was blocking reading the live log streams.

![image](https://github.com/user-attachments/assets/f6be9310-87a2-4318-b35b-b308f40d9e4f)

There is still an issue with logs being persisted to disk.

refs: cloudquery/cloudquery-issues#3321
