### PR TITLE
fix: Handle the case when no port is supplied

### DIFF
--- a/charts/platform/templates/configmap-init-scripts.yaml
+++ b/charts/platform/templates/configmap-init-scripts.yaml
@@ -42,8 +42,9 @@ data:
     # Parse connection strings
     log_header "Parsing connection strings"
     POSTGRES_DSN=$(cat /secrets/postgresqlDSN)
-    PG_HOST=$(echo "$POSTGRES_DSN" | sed -n 's|.*@\([^:]*\):.*|\1|p')
+    PG_HOST=$(echo "$POSTGRES_DSN" | sed -n 's|.*@\([^:/]*\)[:/].*|\1|p')
     PG_PORT=$(echo "$POSTGRES_DSN" | sed -n 's|.*:\([0-9]*\)/.*|\1|p')
+    PG_PORT=${PG_PORT:-5432}
     log_success "PostgreSQL connection string parsed: $PG_HOST:$PG_PORT"
     
     CLICKHOUSE_DSN=$(cat /secrets/clickhouseDSN)


### PR DESCRIPTION
This is typical with the Neon postgres connection strings e.g.

`postgresql://<user>:<password>@<host>/<db>?sslmode=require`
