### PR TITLE
fix: Adding the `SCHEDULER_K8S_SYNC_FORCE_NAMESPACE` environment variable

### DIFF
--- a/charts/operator/templates/_helpers.tpl
+++ b/charts/operator/templates/_helpers.tpl
@@ -67,6 +67,7 @@ Specifies default environment variables for the scheduler
 {{- define "operator.defaultEnv" -}}
 SCHEDULER_K8S_LEADER_ELECTION_NAMESPACE: {{ .Release.Namespace }}
 SCHEDULER_K8S_SYNC_NAMESPACE: {{ .Release.Namespace }}
+SCHEDULER_K8S_SYNC_FORCE_NAMESPACE: "false"
 {{- end}}
 
 {{/*

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -28,7 +28,7 @@ environment:
   # -- The namespace to use to spawn syncs. If not provided, will be the release namespace.
   SCHEDULER_K8S_SYNC_NAMESPACE: ""
   # -- Force the namespace to SCHEDULER_K8S_SYNC_NAMESPACE.
-  SCHEDULER_K8S_SYNC_FORCE_NAMESPACE: "false"
+  SCHEDULER_K8S_SYNC_FORCE_NAMESPACE: "\"false\""
 
 # -- Node labels for sync pod assignment.
 # See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -27,6 +27,8 @@ environment:
   SCHEDULER_K8S_LEADER_ELECTION_NAMESPACE: ""
   # -- The namespace to use to spawn syncs. If not provided, will be the release namespace.
   SCHEDULER_K8S_SYNC_NAMESPACE: ""
+  # -- Force the namespace to SCHEDULER_K8S_SYNC_NAMESPACE.
+  SCHEDULER_K8S_SYNC_FORCE_NAMESPACE: "false"
 
 # -- Node labels for sync pod assignment.
 # See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector.


### PR DESCRIPTION
This allows the scheduler to be put in a mode that will force syncs to only launch in a nominated namespace.
