### PR TITLE
fix: Wait for pod shut down before restarting

### DIFF
--- a/charts/platform/templates/deployments.yaml
+++ b/charts/platform/templates/deployments.yaml
@@ -7,6 +7,8 @@ metadata:
     app.kubernetes.io/component: application
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "platform.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
Rather than using the rolling restart, which can result in EBS volume attachment errors, this changes the deployment strategy to first stop the existing pod before creating (and attaching to the EBS volume) a new pod.

This should hopefully prevent the EBS volume permission issues, but we will probably want to look into a better solution (e.g. statefulsets or alternative storage options) in the long run.

refs: https://github.com/cloudquery/cloudquery-issues/issues/3446
