### PR TITLE
fix: Add liveness and readiness probes to otel-collector

### DIFF
--- a/charts/platform/templates/otelcollector.yaml
+++ b/charts/platform/templates/otelcollector.yaml
@@ -54,6 +54,14 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.otelCollector.resources | nindent 12 }}
+          {{- with .Values.otelCollector.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.otelCollector.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: collector-config
               mountPath: /conf

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -140,6 +140,17 @@ otelCollector:
       cpu: 1000m
       memory: 1Gi
 
+  livenessProbe:
+    periodSeconds: 60
+    httpGet:
+      path: /
+      port: 13133
+  readinessProbe:
+    periodSeconds: 30
+    httpGet:
+      path: /
+      port: 13133
+
   service:
     type: ClusterIP
     ports:


### PR DESCRIPTION
We were missing liveness and readiness checks for the otel-collector, leaving it possible for the container to hang and be non-responsive.