### PR TITLE
fix: Manual update to `1.2.0` cloudquery container

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
     email: yp@cloudquery.io
 type: application
 version: 0.10.1
-appVersion: 1.1.0
+appVersion: 1.2.0
 annotations:
   artifacthub.io/license: MPL-2.0
   artifacthub.io/links: |

--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
   - name: yevgenypats
     email: yp@cloudquery.io
 version: 0.16.4
-appVersion: 1.1.0
+appVersion: 1.2.0
 annotations:
   artifacthub.io/license: MPL-2.0
   artifacthub.io/links: |


### PR DESCRIPTION
Manual update to be faster than the renovate cycle.