### PR TITLE
feat: Adds user and password support.

### DIFF
--- a/charts/platform/ci/test-values.yaml
+++ b/charts/platform/ci/test-values.yaml
@@ -7,5 +7,7 @@ testingSecret:
   clickhouseDSN: "clickhouse://user:pass@172.17.0.1:9000/assets"
   rudderstackBackendWriteKey: "testRudderStackKey"
   rudderstackFrontendWriteKey: "testRudderStackKey"
+  adminEmail: "admin@localhost"
+  adminPassword: "pass"
 otelCollector:
   database: "assets"

--- a/charts/platform/templates/deployments.yaml
+++ b/charts/platform/templates/deployments.yaml
@@ -131,6 +131,16 @@ spec:
               value: "false"
             - name: NEXT_PUBLIC_RUDDERSTACK_DATAPLANE_URL
               value: "https://analytics-events.cloudquery.io"
+            - name: CQAPI_LOCAL_ADMIN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "platform.secretRef" . }}
+                  key: adminEmail
+            - name: CQAPI_LOCAL_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "platform.secretRef" . }}
+                  key: adminPassword
           ports:
             - name: proxy
               containerPort: {{ .Values.service.targetPort }}

--- a/charts/platform/templates/secrets.yaml
+++ b/charts/platform/templates/secrets.yaml
@@ -14,6 +14,8 @@ data:
   privateKey: {{ (genPrivateKey "rsa") | b64enc }}
   rudderstackBackendWriteKey: {{ .Values.testingSecret.rudderstackBackendWriteKey | b64enc }}
   rudderstackFrontendWriteKey: {{ .Values.testingSecret.rudderstackFrontendWriteKey | b64enc }}
+  adminEmail: {{ .Values.testingSecret.adminEmail | b64enc }}
+  adminPassword: {{ .Values.testingSecret.adminPassword | b64enc }}
 ---
 {{- end}}
 {{- if index .Values "externalSecrets" "enabled" }}

--- a/charts/platform/templates/secrets.yaml
+++ b/charts/platform/templates/secrets.yaml
@@ -55,4 +55,12 @@ spec:
       remoteRef:
         key: {{ required "externalSecrets.cloudquerySecretsKey is required" (index .Values "externalSecrets" "cloudquerySecretsKey") }}
         property: rudderstack_frontend_write_key
+    - secretKey: adminEmail
+      remoteRef:
+        key: {{ required "externalSecrets.cloudquerySecretsKey is required" (index .Values "externalSecrets" "cloudquerySecretsKey") }}
+        property: admin_email
+    - secretKey: adminPassword
+      remoteRef:
+        key: {{ required "externalSecrets.cloudquerySecretsKey is required" (index .Values "externalSecrets" "cloudquerySecretsKey") }}
+        property: admin_password
 {{- end }}


### PR DESCRIPTION
Adds support for first user/password. Required for multi-tenancy setup where user/password will be provided by CloudAPI add stored in SSM.


Note:
Changes depend on PR : https://github.com/cloudquery/cloud-infrastructure/pull/330