### PR TITLE
feat: Add ttlSecondsAfterFinished configuration to chart

### DIFF
--- a/charts/cloudquery/templates/job.yaml
+++ b/charts/cloudquery/templates/job.yaml
@@ -8,6 +8,7 @@ metadata:
   {{- include "cloudquery.annotations" . }}
 spec:
   backoffLimit: 0
+  ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished | default 259200 }}
   template:
     metadata:
       labels:

--- a/charts/cloudquery/values.yaml
+++ b/charts/cloudquery/values.yaml
@@ -82,8 +82,8 @@ cronJobFailedJobsLimit: 1
 job:
   # -- Create a job that runs once upon installation.
   enabled: false
-  # -- (int) How long to retain the job after it has finished.
-  ttlSecondsAfterFinished: 259200 # 3 days
+  # -- (int) How long to retain the job after it has finished. Default is 259200 seconds (3 days).
+  ttlSecondsAfterFinished: 259200
 
 # -- CloudQuery cloudquery.yml content
 # @default -- The chart will use a default CloudQuery aws config

--- a/charts/cloudquery/values.yaml
+++ b/charts/cloudquery/values.yaml
@@ -82,6 +82,8 @@ cronJobFailedJobsLimit: 1
 job:
   # -- Create a job that runs once upon installation.
   enabled: false
+  # -- (int) How long to retain the job after it has finished.
+  ttlSecondsAfterFinished: 259200 # 3 days
 
 # -- CloudQuery cloudquery.yml content
 # @default -- The chart will use a default CloudQuery aws config


### PR DESCRIPTION
It should allow Kubernetes to automatically clean up jobs after a specified period, defaults to 3 days.