### PR TITLE
feat: Add support for rbac resources

### DIFF
--- a/charts/cloudquery/README.md
+++ b/charts/cloudquery/README.md
@@ -22,7 +22,7 @@ Kubernetes: `^1.8.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| <https://grafana.github.io/helm-charts> | promtail | 6.16.6 |
+| https://grafana.github.io/helm-charts | promtail | 6.16.6 |
 
 ## Values
 
@@ -32,7 +32,7 @@ Kubernetes: `^1.8.0-0`
 | annotations | object | `{}` | Optional. Additional annotations to be applied to all resources. |
 | config | string | The chart will use a default CloudQuery aws config | CloudQuery cloudquery.yml content |
 | containerSecurityContext | object | See [values.yaml](./values.yaml) | Container security context |
-| cronJobAdditionalArgs | list | `[]` | Optional. Additional CLI arguments to pass to the scheduled sync job (e.g. setting log format) More information at: <https://www.cloudquery.io/docs/reference/cli/cloudquery> |
+| cronJobAdditionalArgs | list | `[]` | Optional. Additional CLI arguments to pass to the scheduled sync job (e.g. setting log format) More information at: https://www.cloudquery.io/docs/reference/cli/cloudquery |
 | cronJobFailedJobsLimit | int | `1` | Number of failed cronjobs to retain. |
 | cronJobLimit | int | `3` | Number of successful cronjobs to retain. |
 | cronJobPodAnnotations | object | `{}` | Optional. CronJob Pod annotations. |
@@ -60,15 +60,15 @@ Kubernetes: `^1.8.0-0`
 | rbac.name | string | `"cloudquery-read-only"` | Name of the ClusterRole and ClusterRoleBinding |
 | resources.admin | object | `{"requests":{"cpu":"1000m","memory":"1024Mi"}}` | Optional. Resource requests/ limit for admin pod. |
 | resources.cronJob | object | `{"requests":{"cpu":"1000m","memory":"1024Mi"}}` | Optional. Resource requests/ limit for cronJob. |
-| schedule | string | `"0 */6 * * *"` | Schedule fetch time Every 6 hours. More information at: <https://crontab.guru/#0_0>_*_*_* |
+| schedule | string | `"0 */6 * * *"` | Schedule fetch time Every 6 hours. More information at: https://crontab.guru/#0_0_*_*_* |
 | secretRef | string | `nil` | Reference to an external secret that contains sensible environment variables This option is useful to avoid store sensitive values in Git. You need to create the secret manually and reference it. If secretRef is used, the envRenderSecret parameter will be omitted (in case that it has content). |
 | securityContext | object | `{"fsGroup":1001}` | Pod security context |
-| serviceAccount.annotations | object | `{}` | Additional custom annotations for the ServiceAccount to associate an AWS IAM role with service-account you need to add the following annotations. For more info checkout: <https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html> eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/ROLE |
+| serviceAccount.annotations | object | `{}` | Additional custom annotations for the ServiceAccount to associate an AWS IAM role with service-account you need to add the following annotations. For more info checkout: https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/ROLE |
 | serviceAccount.autoMount | bool | `false` | Auto-mount the service account token in the pod |
 | serviceAccount.enabled | bool | `false` | Enable service account (Note: Service Account will only be automatically created if `serviceAccount.name` is not set) |
 | serviceAccount.labels | object | `{}` | Additional custom label for the ServiceAccount |
 | serviceAccount.name | string | `""` | Name of an already existing service account. Setting this value disables the automatic service account creation |
-| tplConfig | bool | `false` | Pass the configuration directives and envRenderSecret through Helm's templating engine. # ref: <https://helm.sh/docs/developing_charts/#using-the-tpl-function> |
+| tplConfig | bool | `false` | Pass the configuration directives and envRenderSecret through Helm's templating engine. # ref: https://helm.sh/docs/developing_charts/#using-the-tpl-function |
 | volumeMounts | string | `nil` |  |
 | volumes | string | `nil` |  |
 

--- a/charts/cloudquery/README.md
+++ b/charts/cloudquery/README.md
@@ -22,7 +22,7 @@ Kubernetes: `^1.8.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://grafana.github.io/helm-charts | promtail | 6.16.6 |
+| <https://grafana.github.io/helm-charts> | promtail | 6.16.6 |
 
 ## Values
 
@@ -32,7 +32,7 @@ Kubernetes: `^1.8.0-0`
 | annotations | object | `{}` | Optional. Additional annotations to be applied to all resources. |
 | config | string | The chart will use a default CloudQuery aws config | CloudQuery cloudquery.yml content |
 | containerSecurityContext | object | See [values.yaml](./values.yaml) | Container security context |
-| cronJobAdditionalArgs | list | `[]` | Optional. Additional CLI arguments to pass to the scheduled sync job (e.g. setting log format) More information at: https://www.cloudquery.io/docs/reference/cli/cloudquery |
+| cronJobAdditionalArgs | list | `[]` | Optional. Additional CLI arguments to pass to the scheduled sync job (e.g. setting log format) More information at: <https://www.cloudquery.io/docs/reference/cli/cloudquery> |
 | cronJobFailedJobsLimit | int | `1` | Number of failed cronjobs to retain. |
 | cronJobLimit | int | `3` | Number of successful cronjobs to retain. |
 | cronJobPodAnnotations | object | `{}` | Optional. CronJob Pod annotations. |
@@ -52,17 +52,23 @@ Kubernetes: `^1.8.0-0`
 | nameOverride | string | `""` | Partially override common.names.fullname template (will maintain the release name) |
 | nodeSelector | object | `{}` | Optional. Adds the nodeSelector to the admin pod and cronjob. |
 | promtail | object | See [values.yaml](./values.yaml) | Promtail sub-chart configuration |
+| rbac | object | `{"annotations":{},"apiVersion":"v1","create":false,"labels":{},"name":"cloudquery-read-only"}` | RBAC configuration |
+| rbac.annotations | object | `{}` | Additional annotations to be applied to the ClusterRole and ClusterRoleBinding |
+| rbac.apiVersion | string | `"v1"` | API version of the ClusterRoleBinding |
+| rbac.create | bool | `false` | Create the ClusterRole and ClusterRoleBinding |
+| rbac.labels | object | `{}` | Additional labels to be applied to the ClusterRole and ClusterRoleBinding |
+| rbac.name | string | `"cloudquery-read-only"` | Name of the ClusterRole and ClusterRoleBinding |
 | resources.admin | object | `{"requests":{"cpu":"1000m","memory":"1024Mi"}}` | Optional. Resource requests/ limit for admin pod. |
 | resources.cronJob | object | `{"requests":{"cpu":"1000m","memory":"1024Mi"}}` | Optional. Resource requests/ limit for cronJob. |
-| schedule | string | `"0 */6 * * *"` | Schedule fetch time Every 6 hours. More information at: https://crontab.guru/#0_0_*_*_* |
+| schedule | string | `"0 */6 * * *"` | Schedule fetch time Every 6 hours. More information at: <https://crontab.guru/#0_0>_*_*_* |
 | secretRef | string | `nil` | Reference to an external secret that contains sensible environment variables This option is useful to avoid store sensitive values in Git. You need to create the secret manually and reference it. If secretRef is used, the envRenderSecret parameter will be omitted (in case that it has content). |
 | securityContext | object | `{"fsGroup":1001}` | Pod security context |
-| serviceAccount.annotations | object | `{}` | Additional custom annotations for the ServiceAccount to associate an AWS IAM role with service-account you need to add the following annotations. For more info checkout: https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/ROLE |
+| serviceAccount.annotations | object | `{}` | Additional custom annotations for the ServiceAccount to associate an AWS IAM role with service-account you need to add the following annotations. For more info checkout: <https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html> eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/ROLE |
 | serviceAccount.autoMount | bool | `false` | Auto-mount the service account token in the pod |
 | serviceAccount.enabled | bool | `false` | Enable service account (Note: Service Account will only be automatically created if `serviceAccount.name` is not set) |
 | serviceAccount.labels | object | `{}` | Additional custom label for the ServiceAccount |
 | serviceAccount.name | string | `""` | Name of an already existing service account. Setting this value disables the automatic service account creation |
-| tplConfig | bool | `false` | Pass the configuration directives and envRenderSecret through Helm's templating engine. # ref: https://helm.sh/docs/developing_charts/#using-the-tpl-function |
+| tplConfig | bool | `false` | Pass the configuration directives and envRenderSecret through Helm's templating engine. # ref: <https://helm.sh/docs/developing_charts/#using-the-tpl-function> |
 | volumeMounts | string | `nil` |  |
 | volumes | string | `nil` |  |
 

--- a/charts/cloudquery/templates/_helpers.tpl
+++ b/charts/cloudquery/templates/_helpers.tpl
@@ -77,6 +77,17 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Create the name of the cluster role to use
+*/}}
+{{- define "cloudquery.clusterRoleName" -}}
+{{- if .Values.rbac.create }}
+{{- default (include "cloudquery.fullname" .) .Values.rbac.name }}
+{{- else }}
+{{- default "default" .Values.rbac.name }}
+{{- end }}
+{{- end }}
+
+{{/*
 Return the image to use depending on the AppVersion and image tag defined
 */}}
 {{- define "cloudquery.image" -}}

--- a/charts/cloudquery/templates/clusterrole.yaml
+++ b/charts/cloudquery/templates/clusterrole.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
+kind: ClusterRole
+metadata:
+  name: {{ include "cloudquery.clusterRoleName" . }}
+  labels:
+    {{- include "cloudquery.labels" . | nindent 4 }}
+    {{- with .Values.rbac.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.rbac.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups:
+      - "*"
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+  - nonResourceURLs:
+      - "*"
+    verbs:
+      - get
+      - list
+{{- end }}

--- a/charts/cloudquery/templates/clusterrolebinding.yaml
+++ b/charts/cloudquery/templates/clusterrolebinding.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "cloudquery.clusterRoleName" . }}
+  labels:
+    {{- include "cloudquery.labels" . | nindent 4 }}
+    {{- with .Values.rbac.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.rbac.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "cloudquery.clusterRoleName" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "cloudquery.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/cloudquery/values.yaml
+++ b/charts/cloudquery/values.yaml
@@ -36,6 +36,19 @@ serviceAccount:
   # -- Additional custom label for the ServiceAccount
   labels: {}
 
+# -- RBAC configuration
+rbac:
+  # -- Create the ClusterRole and ClusterRoleBinding
+  create: false
+  # -- Name of the ClusterRole and ClusterRoleBinding
+  name: cloudquery-read-only
+  # -- API version of the ClusterRoleBinding
+  apiVersion: v1
+  # -- Additional labels to be applied to the ClusterRole and ClusterRoleBinding
+  labels: {}
+  # -- Additional annotations to be applied to the ClusterRole and ClusterRoleBinding
+  annotations: {}
+
 admin:
   # -- Enable admin container
   # useful for debugging into cloudquery
@@ -111,7 +124,6 @@ volumes:
 
 # Optional. Additional volumes to mount in the pod.
 volumeMounts:
-
 
 resources:
   # -- Optional. Resource requests/ limit for admin pod.


### PR DESCRIPTION
This PR adds some basic support for RBAC as documented here: https://hub.cloudquery.io/plugins/source/cloudquery/k8s/latest/docs#kubernetes-service-account

Given that a kubernetes deployment of `cloudquery` can't really work without a corresponding role, it might be useful to include it.

The feature is off by default (`rbac.create = false`). And should continue to produce the previous configuration unless the user wants the rbac functionality turned on.

I went ahead and version-bumped the `Chart.yaml` file. Not sure if that's required, or handled by CI. Please let me know if I need to make any changes. 